### PR TITLE
docs(progress): remove size and theme related content

### DIFF
--- a/src/progress/progress.md
+++ b/src/progress/progress.md
@@ -8,8 +8,6 @@
 color | String / Object / Array | '' | 进度条颜色。示例：'#ED7B2F' 或 'orange' 或 `['#f00', '#0ff', '#f0f']` 或 `{ '0%': '#f00', '100%': '#0ff' }` 或  `{ from: '#000', to: '#000' }` 等。TS 类型：`string | Array<string> | Record<string, string>` | N
 label | String / Boolean / Slot / Function | true | 进度百分比，可自定义。TS 类型：`string | boolean | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 percentage | Number | 0 | 进度条百分比 | N
-size | String / Number | 'medium' | 进度条尺寸，示例：small/medium/large/240。small 值为 72； medium 值为 112；large 值为 160 | N
 status | String | - | 进度条状态。可选项：success/error/warning/active。TS 类型：`StatusEnum` `type StatusEnum = 'success' | 'error' | 'warning' | 'active'`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/progress/type.ts) | N
 strokeWidth | String / Number | - | 进度条线宽。宽度数值不能超过 size 的一半，否则不能输出环形进度 | N
-theme | String | line | 进度条风格。值为 line，标签（label）显示在进度条右侧；值为 plump，标签（label）显示在进度条里面；值为 circle，标签（label）显示在进度条正中间。可选项：line/plump/circle。TS 类型：`ThemeEnum` `type ThemeEnum = 'line' | 'plump' | 'circle'`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/progress/type.ts) | N
 trackColor | String | '' | 进度条未完成部分颜色 | N

--- a/src/progress/props.ts
+++ b/src/progress/props.ts
@@ -23,11 +23,6 @@ export default {
     type: Number,
     default: 0,
   },
-  /** 进度条尺寸，示例：small/medium/large/240。small 值为 72； medium 值为 112；large 值为 160 */
-  size: {
-    type: [String, Number] as PropType<TdProgressProps['size']>,
-    default: 'medium',
-  },
   /** 进度条状态 */
   status: {
     type: String as PropType<TdProgressProps['status']>,
@@ -39,15 +34,6 @@ export default {
   /** 进度条线宽。宽度数值不能超过 size 的一半，否则不能输出环形进度 */
   strokeWidth: {
     type: [String, Number] as PropType<TdProgressProps['strokeWidth']>,
-  },
-  /** 进度条风格。值为 line，标签（label）显示在进度条右侧；值为 plump，标签（label）显示在进度条里面；值为 circle，标签（label）显示在进度条正中间 */
-  theme: {
-    type: String as PropType<TdProgressProps['theme']>,
-    default: 'line' as TdProgressProps['theme'],
-    validator(val: TdProgressProps['theme']): boolean {
-      if (!val) return true;
-      return ['line', 'plump', 'circle'].includes(val);
-    },
   },
   /** 进度条未完成部分颜色 */
   trackColor: {

--- a/src/progress/type.ts
+++ b/src/progress/type.ts
@@ -23,11 +23,6 @@ export interface TdProgressProps {
    */
   percentage?: number;
   /**
-   * 进度条尺寸，示例：small/medium/large/240。small 值为 72； medium 值为 112；large 值为 160
-   * @default 'medium'
-   */
-  size?: string | number;
-  /**
    * 进度条状态
    */
   status?: StatusEnum;
@@ -36,11 +31,6 @@ export interface TdProgressProps {
    */
   strokeWidth?: string | number;
   /**
-   * 进度条风格。值为 line，标签（label）显示在进度条右侧；值为 plump，标签（label）显示在进度条里面；值为 circle，标签（label）显示在进度条正中间
-   * @default line
-   */
-  theme?: ThemeEnum;
-  /**
    * 进度条未完成部分颜色
    * @default ''
    */
@@ -48,5 +38,3 @@ export interface TdProgressProps {
 }
 
 export type StatusEnum = 'success' | 'error' | 'warning' | 'active';
-
-export type ThemeEnum = 'line' | 'plump' | 'circle';


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 文档改进

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-mobile-vue/issues/175

### 💡 需求背景和解决方案

方案：鉴于[小程序端](https://tdesign.tencent.com/miniprogram/components/progress?tab=api)目前也未实现 size 、theme 属性，将文档中size 、theme 相关内容移进行移除。

### 📝 更新日志
- refactor(progress): 移除 `theme` 和 `size` 未实现的属性

