### PR TITLE
fix:  修复滑块滑到最左侧时，遮挡左侧最小值文本

### DIFF
--- a/src/slider/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/slider/__test__/__snapshots__/demo.test.jsx.snap
@@ -89,7 +89,7 @@ exports[`Slider > Slider disableVue demo works fine 1`] = `
       data-v-65b1e7f4=""
     >
       <div
-        class="t-slider-wrap__value-left"
+        class="t-slider-wrap__value--left"
       >
         30
       </div>
@@ -431,7 +431,7 @@ exports[`Slider > Slider mobileVue demo works fine 1`] = `
         data-v-98828574=""
       >
         <div
-          class="t-slider-wrap__value-left"
+          class="t-slider-wrap__value--left"
         >
           30
         </div>
@@ -666,7 +666,7 @@ exports[`Slider > Slider mobileVue demo works fine 1`] = `
           data-v-65b1e7f4=""
         >
           <div
-            class="t-slider-wrap__value-left"
+            class="t-slider-wrap__value--left"
           >
             30
           </div>

--- a/src/slider/slider.vue
+++ b/src/slider/slider.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="rootRef" :class="classes">
-    <div v-if="showExtremeValue" :class="`${name}-wrap__value-left`">{{ min }}</div>
+    <div v-if="showExtremeValue" :class="`${name}-wrap__value--left`">{{ min }}</div>
     <div :class="`${name}`" @click="onClick">
       <!-- 总长度 -->
       <div ref="barRef" :class="`${name}__bar`"></div>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
#277 

### 📝 更新日志

- fix(Slider): 修复滑块滑到最左侧时，左侧文本被遮挡

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
