### PR TITLE
feat: 针对popup、drawer增加点击遮罩层是否触发关闭事件的配置

### DIFF
--- a/src/drawer/drawer.md
+++ b/src/drawer/drawer.md
@@ -10,6 +10,7 @@ placement | String | right | 抽屉方向。可选项：left/right/top/bottom | 
 showOverlay | Boolean | true | 是否显示遮罩层 | N
 visible | Boolean | false | 组件是否可见 | N
 zIndex | Number | - | 抽屉层级，样式默认为 1500 | N
+closeOverlayClick | Boolean | - | 点击遮罩层是否触发关闭事件 | N
 onClose | Function |  | TS 类型：`(context: DrawerCloseContext) => void`<br/>关闭事件，取消按钮点击时、关闭按钮点击时、ESC 按下时、点击蒙层时均会触发。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/drawer/type.ts)。<br/>`type DrawerEventSource = 'esc' | 'close-btn' | 'cancel' | 'overlay'`<br/><br/>`interface DrawerCloseContext { trigger: DrawerEventSource; e: MouseEvent | KeyboardEvent }`<br/> | N
 onItemClick | Function |  | TS 类型：`( index: number, item: DrawerItem, context: { e: MouseEvent }) => void`<br/>点击抽屉里的列表项 | N
 onOverlayClick | Function |  | TS 类型：`(context: { e: MouseEvent }) => void`<br/>如果蒙层存在，点击蒙层时触发 | N

--- a/src/drawer/drawer.vue
+++ b/src/drawer/drawer.vue
@@ -4,6 +4,7 @@
     :placement="placement"
     :show-overlay="showOverlay"
     :z-index="zIndex"
+    :close-overlay-click="closeOverlayClick"
     @visible-change="onVisibleChange"
     @close="onClose"
   >
@@ -39,7 +40,7 @@ export default defineComponent({
   emits: ['update:visible', 'itemClick', 'overlayClick'],
   setup(props, context: SetupContext) {
     const emitEvent = useEmitEvent(props, context.emit);
-    const { visible, items, placement, showOverlay, zIndex } = toRefs(props);
+    const { visible, items, placement, showOverlay, zIndex, closeOverlayClick } = toRefs(props);
     const open = ref(visible.value || false);
 
     const dSideBarClassName = computed(() => `${name}__sidebar`);
@@ -74,6 +75,7 @@ export default defineComponent({
       placement,
       showOverlay,
       zIndex,
+      closeOverlayClick,
       open,
       dSideBarClassName,
       dSideBarItemClassName,

--- a/src/drawer/props.ts
+++ b/src/drawer/props.ts
@@ -75,6 +75,11 @@ export default {
   zIndex: {
     type: Number,
   },
+  /** 点击遮罩层是否触发关闭 */
+  closeOverlayClick: {
+    type: Boolean,
+    default: true,
+  },
   /** 关闭事件，取消按钮点击时、关闭按钮点击时、ESC 按下时、点击蒙层时均会触发 */
   onClose: Function as PropType<TdDrawerProps['onClose']>,
   /** 点击抽屉里的列表项 */

--- a/src/popup/popup.md
+++ b/src/popup/popup.md
@@ -13,6 +13,7 @@ transitionName | String | - | 弹出层内容区的动画名，等价于transiti
 visible | Boolean | false | 是否显示浮层。支持语法糖 `v-model` 或 `v-model:visible`。TS 类型：`boolean` | N
 defaultVisible | Boolean | false | 是否显示浮层。非受控属性。TS 类型：`boolean` | N
 zIndex | Number | - | 组件层级，Web 侧样式默认为 5500，移动端和小程序样式默认为 1500 | N
+closeOverlayClick | Boolean | - | 点击遮罩层是否触发关闭事件 | N
 onClose | Function |  | TS 类型：`() => void`<br/>组件准备关闭时触发 | N
 onClosed | Function |  | TS 类型：`() => void`<br/>组件关闭且动画结束后执行 | N
 onOpen | Function |  | TS 类型：`() => void`<br/>组件准备展示时触发 | N

--- a/src/popup/popup.vue
+++ b/src/popup/popup.vue
@@ -71,6 +71,9 @@ export default defineComponent({
     );
 
     const handleOverlayClick = () => {
+      if (!props.closeOverlayClick) {
+        return;
+      }
       emitEvent('close');
       currentVisible.value = false;
     };

--- a/src/popup/props.ts
+++ b/src/popup/props.ts
@@ -51,6 +51,11 @@ export default {
   zIndex: {
     type: Number,
   },
+  /** 点击遮罩层是否触发关闭 */
+  closeOverlayClick: {
+    type: Boolean,
+    default: true,
+  },
   /** 组件准备关闭时触发 */
   onClose: Function as PropType<TdPopupProps['onClose']>,
   /** 组件关闭且动画结束后执行 */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-mobile-vue/issues/266

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
新增属性：点击遮罩层是否触发关闭事件

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
新增closeOnOverlayClick属性：点击遮罩层是否触发关闭事件
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
