### PR TITLE
test: add unit test for picker

### DIFF
--- a/src/picker/__test__/index.test.jsx
+++ b/src/picker/__test__/index.test.jsx
@@ -1,0 +1,322 @@
+import { nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Picker from '../picker.vue';
+import PickerItem from '../picker-item.vue';
+
+import { DEFAULT_ITEM_HEIGHT, ANIMATION_TIME_LIMIT } from '../picker.class';
+
+const seasonOptions = [
+  { label: '春', value: 'spring' },
+  { label: '夏', value: 'summer' },
+  { label: '秋', value: 'autumn' },
+  { label: '冬', value: 'winter' },
+];
+
+const commonProps = {
+  columns: [seasonOptions],
+  defaultValue: [seasonOptions[0].value],
+};
+
+const mountPicker = (props) => mount(Picker, {
+  props: {...commonProps, ...props}
+});
+
+const makeTouch = (el, eventName, touchPosition) => {
+  const event = new Event(eventName);
+  if (touchPosition) {
+    event.changedTouches = [touchPosition];
+  }
+
+  el.dispatchEvent(event);
+};
+
+const simulateMoveOption = async (optionContainerEl, distance) => {
+  makeTouch(optionContainerEl, 'touchstart', { pageY: 0 });
+  makeTouch(optionContainerEl, 'touchmove', { pageY: -distance * DEFAULT_ITEM_HEIGHT });
+
+  vi.useFakeTimers().advanceTimersByTime(ANIMATION_TIME_LIMIT + 1);
+  makeTouch(optionContainerEl, 'touchend', { pageY: -distance * DEFAULT_ITEM_HEIGHT });
+  vi.useRealTimers();
+
+  await nextTick();
+}
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('picker', () => {
+  describe('props', () => {
+    it(': cancelBtn', () => {
+      const testCancelBtn = (cancelBtn) => {
+        const wrapper = mountPicker({ cancelBtn });
+        const textContainer = wrapper.find('.t-picker__cancel');
+        expect(textContainer.text()).toBe(cancelBtn || '取消');
+      }
+
+      testCancelBtn();
+      testCancelBtn('Cancel');
+    });
+
+    it(': confirmBtn', () => {
+      const testConfirmBtn = (confirmBtn) => {
+        const wrapper = mountPicker({ confirmBtn })
+        const textContainer = wrapper.find('.t-picker__confirm');
+        expect(textContainer.text()).toBe(confirmBtn || '确认');
+      }
+
+      testConfirmBtn();
+      testConfirmBtn('Confirm');
+    });
+
+    it(': title', () => {
+      const testTitle = (title) => {
+        const wrapper = mountPicker({ title })
+        const textContainer = wrapper.find('.t-picker__title');
+        expect(textContainer.text()).toBe(title || '');
+      };
+
+      testTitle();
+      testTitle('Choose Season');
+    });
+
+    it(': renderLabel', () => {
+      const renderLabel = (item) => `${item.label} ${item.value}`;
+      const wrapper = mountPicker({ renderLabel });
+      const itemContainers = wrapper.findAll('.t-picker-item__item');
+      expect(itemContainers).toHaveLength(seasonOptions.length);
+
+      itemContainers.forEach(
+        (container, index) => expect(container.text()).toBe(renderLabel(seasonOptions[index]))
+      );
+    })
+
+    it(': defaultValue', () => {
+      const selector = '.t-picker-item__item--selected'
+      // valid option value
+      let wrapper = mountPicker({ defaultValue: [seasonOptions[1].value] });
+      let textContainer = wrapper.find(selector);
+      expect(textContainer.text()).toBe(seasonOptions[1].label);
+
+      // invalid option value
+      wrapper = mountPicker({ defaultValue: ['NOT_EXIST'] });
+      textContainer = wrapper.find(selector);
+      expect(textContainer.text()).toBe(seasonOptions[0].label);
+    });
+
+    it(': columns', () => {
+      const testColumns = (columns, isValidColumns = true ) => {
+        const wrapper = mountPicker({ columns });
+        const itemContainers = wrapper.findAll('.t-picker-item__item');
+
+        if (!isValidColumns) {
+          return expect(itemContainers).toHaveLength(0);
+        }
+
+        expect(itemContainers).toHaveLength(seasonOptions.length);
+        itemContainers.forEach(
+          (container, index) => expect(container.text()).toBe(seasonOptions[index].label)
+        );
+      };
+
+      testColumns([ undefined ], false);
+      testColumns(undefined, false);
+      testColumns([seasonOptions]);
+      testColumns(() => ([seasonOptions]));
+    });
+
+    it(': value', async () => {
+      const value = ref([seasonOptions[1].value]);
+      const wrapper =  mount( <Picker v-model={value.value} {...commonProps}/>);
+      const textContainer = wrapper.find('.t-picker-item__item--selected');
+      expect(textContainer.text()).toBe(seasonOptions[1].label);
+
+      await simulateMoveOption(wrapper.find('.t-picker-item').element, 2);
+      await wrapper.find('.t-picker__confirm').trigger('click');
+      expect(value.value).toStrictEqual([seasonOptions[3].value]);
+    });
+  });
+
+  describe('event', () => {
+    it(': cancel', async () => {
+      const onCancel = vi.fn();
+      const wrapper = mountPicker({ onCancel });
+      await wrapper.find('.t-picker__cancel').trigger('click');
+
+      expect(onCancel).toBeCalledTimes(1);
+    });
+
+    it(': change', async () => {
+      const onChange = vi.fn();
+      const wrapper = mountPicker({ onChange });
+      await simulateMoveOption(wrapper.find('.t-picker-item').element, 2);
+      await wrapper.find('.t-picker__confirm').trigger('click');
+      expect(onChange).toBeCalledTimes(1);
+      expect(onChange).toBeCalledWith([ seasonOptions[2].value ]);
+    });
+
+    it(': confirm', async () => {
+      const onConfirm = vi.fn();
+      const wrapper = mountPicker({ onConfirm });
+      await simulateMoveOption(wrapper.find('.t-picker-item').element, 2);
+      await wrapper.find('.t-picker__confirm').trigger('click');
+      expect(onConfirm).toBeCalledTimes(1);
+      expect(onConfirm).toBeCalledWith([ seasonOptions[2].value ], { index: [ 2 ] });
+    });
+
+    it(': pick', async () => {
+      // columns is static array
+      const onPick = vi.fn();
+      let wrapper = mountPicker({ onPick, columns: [ seasonOptions ] });
+      await simulateMoveOption(wrapper.find('.t-picker-item').element, 2);
+      expect(onPick).toBeCalledTimes(1);
+      expect(onPick).toBeCalledWith([ seasonOptions[2].value ], { column: 0, index: 2 });
+
+      // columns is function, can change dynamically
+      let monthOptions = [];
+      const columns = (item = seasonOptions[0].value) => {
+        switch (item[0]) {
+          case 'spring':
+            monthOptions = [
+              { label: '一月', value: 'January' },
+              { label: '二月', value: 'February' },
+              { label: '三月', value: 'March' },
+            ];
+            break;
+          case 'summer':
+            monthOptions = [
+              { label: '四月', value: 'April' },
+              { label: '五月', value: 'May' },
+              { label: '六月', value: 'June' },
+            ];
+            break;
+          case 'autumn':
+            monthOptions = [
+              { label: '七月', value: 'July' },
+              { label: '八月', value: 'August' },
+              { label: '九月', value: 'September' },
+            ];
+            break;
+          case 'winter':
+            monthOptions = [
+              { label: '十月', value: 'October' },
+              { label: '十一月', value: 'November' },
+              { label: '十二月', value: 'December' },
+            ];
+            break;
+          default:
+            throw new Error('unexpected item!');
+        }
+        return [
+          seasonOptions,
+          monthOptions,
+        ]
+      };
+
+      wrapper = mountPicker({ onPick, columns });
+      await simulateMoveOption(wrapper.find('.t-picker-item').element, 2);
+      expect(onPick).toBeCalledTimes(2);
+      expect(onPick).toBeCalledWith([ seasonOptions[2].value ], { column: 0, index: 2 });
+      const itemContainers = wrapper.findAll('.t-picker-item__item');
+
+      expect(itemContainers).toHaveLength(seasonOptions.length + monthOptions.length);
+      for (let i = 0; i < seasonOptions.length; i++) {
+        expect(itemContainers[i].text()).toBe(seasonOptions[i].label);
+      }
+
+      for (let j = 0; j < monthOptions.length; j++) {
+        expect(itemContainers[seasonOptions.length + j].text()).toBe(monthOptions[j].label);
+      }
+    });
+  });
+
+  describe('picker-item', () => {
+    it(': setIndex', async () => {
+      const pickerItemRef = ref(null);
+      const wrapper = mount({
+        render() {
+          return <PickerItem ref={pickerItemRef} options={seasonOptions} />
+        },
+      });
+
+      pickerItemRef.value.setIndex(2);
+      await nextTick();
+
+      const textContainer = wrapper.find('.t-picker-item__item--selected');
+      expect(textContainer.text()).toBe(seasonOptions[2].label);
+    });
+
+    it(': setValue', async () => {
+      const pickerItemRef = ref(null);
+      const wrapper = mount({
+        render() {
+          return <PickerItem ref={pickerItemRef} options={seasonOptions} />
+        },
+      });
+
+      pickerItemRef.value.setValue(seasonOptions[2].value);
+      await nextTick();
+
+      const textContainer = wrapper.find('.t-picker-item__item--selected');
+      expect(textContainer.text()).toBe(seasonOptions[2].label);
+    });
+
+    it(': setOptions', async () => {
+      const pickerItemRef = ref(null);
+      const optionsRef = ref(seasonOptions);
+      const wrapper = mount({
+        render() {
+          return <PickerItem ref={pickerItemRef} options={optionsRef.value} />
+        },
+      });
+
+      let itemContainers = wrapper.findAll('.t-picker-item__item');
+      expect(itemContainers).toHaveLength(optionsRef.value.length);
+
+      optionsRef.value = [seasonOptions[0]];
+      pickerItemRef.value.setOptions();
+      await nextTick();
+
+      itemContainers = wrapper.findAll('.t-picker-item__item');
+      expect(itemContainers).toHaveLength(optionsRef.value.length);
+    })
+  });
+
+  describe('picker.class.ts', () => {
+    beforeAll(() => {
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(async (cb) => {
+        await sleep(50);
+        cb(Date.now());
+      });
+    });
+
+    afterAll(() => {
+      window.requestAnimationFrame.mockRestore();
+    });
+
+    it(': scroll quickly to trigger animation', async () => {
+      const wrapper = mountPicker();
+      const el = wrapper.find('.t-picker-item').element;
+
+      makeTouch(el, 'touchstart', { pageY: 0 });
+      makeTouch(el, 'touchmove', { pageY: -2 * DEFAULT_ITEM_HEIGHT });
+
+      await sleep(200);
+      makeTouch(el, 'touchend', { pageY: -2 * DEFAULT_ITEM_HEIGHT });
+
+      // waiting for animation
+      await sleep(1000);
+
+      // scroll  to the last one
+      const textContainer = wrapper.find('.t-picker-item__item--selected');
+      expect(textContainer.text()).toBe(seasonOptions[3].label);
+    });
+
+    it(': scroll slowly to prevent animation', async () => {
+      const wrapper = mountPicker();
+      const el = wrapper.find('.t-picker-item').element;
+      simulateMoveOption(el, 2);
+      const textContainer = wrapper.find('.t-picker-item__item--selected');
+      expect(textContainer.text()).toBe(seasonOptions[2].label);
+    })
+  });
+});

--- a/src/picker/picker-item.vue
+++ b/src/picker/picker-item.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import { ref, computed, onMounted, watch, nextTick, toRefs, defineComponent, PropType, SetupContext } from 'vue';
+import { ref, computed, onMounted, toRefs, defineComponent, PropType, SetupContext } from 'vue';
 import config from '../config';
 import Picker from './picker.class';
 import { PickerColumnItem, PickerValue } from './type';

--- a/src/picker/picker.class.ts
+++ b/src/picker/picker.class.ts
@@ -16,10 +16,10 @@ const quartEaseOut = function (t: number, b: number, c: number, d: number) {
 /**
  * constant var
  */
-const DEFAULT_ITEM_HEIGHT = 40;
+export const DEFAULT_ITEM_HEIGHT = 40;
 const DEFAULT_HOLDER_HEIGHT = 200;
 const OFFSET_OF_BOUND = 60;
-const ANIMATION_TIME_LIMIT = 460;
+export const ANIMATION_TIME_LIMIT = 460;
 const ANIMATION_DURATION = 150;
 
 /**

--- a/src/picker/picker.md
+++ b/src/picker/picker.md
@@ -9,7 +9,7 @@
 cancelBtn | String / Object | '取消' | 取消按钮文字。TS 类型：`string | ButtonProps` | N
 columns | Array / Function | [] | 必需。配置每一列的选项。TS 类型：`Array<PickerColumn> | ((item: Array<PickerValue>)  => Array<PickerColumn>)` `type PickerColumn = PickerColumnItem[]` `interface PickerColumnItem { label: string,value: string}`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/picker/type.ts) | Y
 confirmBtn | String / Object | '确认' | 确定按钮文字。TS 类型：`string | ButtonProps`，[Button API Documents](./button?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/picker/type.ts) | N
-renderLabel | String / Function | - | 自定义label。TS 类型：`(item: PickerColumnItem) => string` | N
+renderLabel | Function | - | 自定义label。TS 类型：`(item: PickerColumnItem) => string` | N
 title | String | '' | 标题 | N
 value | Array | - | 选中值。支持语法糖 `v-model` 或 `v-model:value`。TS 类型：`Array<PickerValue>` `type PickerValue = string | number`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/picker/type.ts) | N
 defaultValue | Array | - | 选中值。非受控属性。TS 类型：`Array<PickerValue>` `type PickerValue = string | number`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/picker/type.ts) | N

--- a/src/picker/picker.vue
+++ b/src/picker/picker.vue
@@ -52,8 +52,9 @@ export default defineComponent({
     const emitEvent = useEmitEvent(props, context.emit);
     const { value, modelValue } = toRefs(props);
     const [pickerValue, setPickerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
-    const confirmButtonText = computed(() => props.confirmBtn || '确定');
-    const cancelButtonText = computed(() => props.cancelBtn || '取消');
+    const confirmButtonText = computed(() => props.confirmBtn);
+    const cancelButtonText = computed(() => props.cancelBtn);
+    const curValueArray = ref(pickerValue.value.map((item: PickerValue) => item));
     const realColumns = computed(() => {
       if (typeof props.columns === 'function') {
         const data = props.columns(curValueArray.value);
@@ -61,13 +62,12 @@ export default defineComponent({
       }
       return props.columns;
     });
-    const curValueArray = ref(pickerValue.value.map((item: PickerValue) => item));
     let lastTimeValueArray = [...curValueArray.value];
     let curIndexArray = pickerValue.value.map((item: PickerValue, index: number) => {
       return getIndexFromColumns(realColumns.value, item, index);
     });
     let lastTimeIndexArray = [...curIndexArray];
-    const pickerItemInstanceArray = <any>ref([]);
+    const pickerItemInstanceArray = ref([]) as any;
     onMounted(() => {
       // 获取pickerItem实例，用于更新每个item的value和index
       pickerItemInstanceArray.value = useChildSlots('t-picker-item').map((item) => item.component);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 测试用例


### 💡 需求背景和解决方案

增加组件 Picker 的测试用例：

<img width="957" alt="image" src="https://user-images.githubusercontent.com/28722527/188293829-4cab7cd2-07a6-4bc4-8121-6bf1d93451af.png">

同时发现并修复了一些问题：

1.  默认的确定按钮文案，picker.vue 里是“确定”，picker.md 和 props.ts 是“确认”，目前实际生效的是 **确认**，所以删除 picker.vue 里的默认值（取消按钮文案同理）。
2. picker.md 里 `renderLabel` 类型错误，写的是 `Srting | Function`，但是实际只支持函数，所以修改为仅 `Function` 类型。
3. picker.vue 的 setup 中，`curValueArray` 在定义前使用(ESLint 未拦截这种问题吗？），所以调换了顺序。

还发现了一些问题，tdesign 团队可以后续跟进并修复：

- [ ] cancelBtn / confirmBtn 目前都仅仅支持传入 string，但是文档和类型文件都说支持传入 ButtonProps。
- [ ] visible 属性有在类型和文档中定义，但是没看到使用的地方？
- [ ] defineComponent.emits 里没有写 confirm 事件，但是实际上是会抛出 confirm 事件。
- [ ] 触发的 change 事件，回调函数参数和文档不符，第二个参数没有 column 只有 index。

### 📝 更新日志

- [test(picker): 增加 picker 组件测试用例](https://github.com/Tencent/tdesign-mobile-vue/commit/ca6ce529884eb23551dbeccc882b75035da4c83f)
- [fix(picker): 修复 ESLint 和类型错误](https://github.com/Tencent/tdesign-mobile-vue/commit/57caf494a2e5c18d7344c14796e17862cc4b0676)
