### PR TITLE
fix: extra vnode in dynamicChildren

### DIFF
--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -1,4 +1,4 @@
-import { h, ComponentInternalInstance, Slots, VNode } from 'vue';
+import { h, ComponentInternalInstance, Slots, VNode, setBlockTracking } from 'vue';
 import camelCase from 'lodash/camelCase';
 
 interface JSXRenderContext {
@@ -40,7 +40,12 @@ export const renderTNode = (
     return instance.slots[name] ? instance.slots[name]?.call(params) : defaultNode;
   }
 
-  if (typeof propsNode === 'function') return propsNode(h, params);
+  if (typeof propsNode === 'function') {
+    setBlockTracking(-1);
+    const vnode = propsNode(h, params);
+    setBlockTracking(1);
+    return vnode;
+  }
 
   const isPropsEmpty = [undefined, params, ''].includes(propsNode);
   if (isPropsEmpty && instance.slots[name]) return instance.slots[name]?.call(params);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#629](https://github.com/Tencent/tdesign-mobile-vue/issues/629)

### 💡 需求背景和解决方案

#### 1.需要解决的问题
在template模式执行其生成的sfc_render时，若有h函数的执行，则其生成的节点会往currentBlock里push，导致dynamicChildren的数量可能出现不一致，最终导致渲染异常或报错

#### 2.目前的解决方案
参考源码slot的处理方式，在propsNode是方法时，先使用setBlockTracking(-1)关掉currentBlock的收集，再执行完propsNode方法后，再调用setBlockTracking(1)还原

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: extra vnode in dynamicChildren ([issue #629](https://github.com/Tencent/tdesign-mobile-vue/issues/629))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
