### PR TITLE
build: export reset.css to the dist directory

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -218,4 +218,13 @@ const umdMinConfig = {
   },
 };
 
-export default [cssConfig, esConfig, esmConfig, cjsConfig, umdConfig, umdMinConfig];
+// 单独导出 reset.css 到 dist 目录，兼容旧版本样式
+const resetCss = {
+  input: 'src/_common/style/mobile/_reset.less',
+  output: {
+    file: 'dist/reset.css',
+  },
+  plugins: [postcss({ extract: true })],
+};
+
+export default [cssConfig, esConfig, esmConfig, cjsConfig, umdConfig, umdMinConfig, resetCss];

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -17,21 +17,137 @@ spline: explain
 
 目前组件库已发布一期组件的测试版本，还在快速迭代，注意留意版本变化
 
+### 使用 npm 安装
+
+推荐使用 npm 方式进行开发
+
 ```bash
 npm i tdesign-mobile-vue
 ```
 
+### 通过 浏览器引入 安装
+
+目前可以通过 [unpkg.com/tdesign-mobile-vue](https://unpkg.com/tdesign-mobile-vue) 获取到最新版本的资源，在页面上引入 js 和 css 文件即可开始使用。
+
+```html
+<!-- vue 3 -->
+<script src="https://unpkg.com/vue@next"></script>
+<link rel="stylesheet" href="https://unpkg.com/tdesign-mobile-vue/dist/tdesign.min.css" />
+<script src="https://unpkg.com/tdesign-mobile-vue/dist/tdesign.min.js"></script>
+...
+<script>
+  Vue.createApp({}).use(TDesign).mount('#app');
+</script>
+```
+
+npm package 中提供了多种构建产物，可以阅读 [这里](https://github.com/Tencent/tdesign/blob/main/docs/develop-install.md) 了解不同目录下产物的差别。
+
+
+## 使用
+
+TDesign 提供了三种方式使用组件，具体使用方式如下
+
 ## 基础使用
 
-推荐使用 Webpack 或 Rollup 等支持 tree-shaking 特性的构建工具，无需额外配置即可实现组件按需引入：
+基础使用会全量注册所有组件，如果您的项目大规模使用组件，请放心使用这种方式。
 
 ```js
 import { createApp } from 'vue';
 import TDesign from 'tdesign-mobile-vue';
+import App from './app.vue';
+
+// 引入组件库的少量全局样式变量
+import 'tdesign-mobile-vue/es/style/index.css';
 
 const app = createApp(App);
 app.use(TDesign);
 ```
+
+### 按需引入使用
+
+如果您对产物大小有严格的要求，可以通过 按需引入具体组件 的方式来使用。
+
+借助 Webpack 或 Rollup 等支持 tree-shaking 特性的构建工具，可以达到按需引入的使用效果。
+
+```js
+import { createApp } from 'vue';
+import { Button as TButton } from 'tdesign-mobile-vue';
+import App from './app.vue';
+
+// 引入组件库的少量全局样式变量
+import 'tdesign-mobile-vue/es/style/index.css';
+
+const app = createApp(App);
+app.use(TButton);
+```
+
+### 通过插件按需引用使用
+
+除此之外，也可以使用 `unplugin-vue-components` 和 `unplugin-auto-import` 来实现自动导入：
+
+您仍需在项目引入组件库的少量全局样式变量
+```js
+import { createApp } from 'vue';
+// 引入组件库的少量全局样式变量
+import 'tdesign-mobile-vue//es/style/index.css';
+
+const app = createApp(App);
+```
+并安装两个unplugin相关的第三方包
+```bash
+npm install -D unplugin-vue-components unplugin-auto-import
+```
+
+然后在 Webpack 或 Vite 对应的配置文件添加上述插件。
+
+#### Vite
+
+```js
+import AutoImport from 'unplugin-auto-import/vite';
+import Components from 'unplugin-vue-components/vite';
+import { TDesignResolver } from 'unplugin-vue-components/resolvers';
+export default {
+  plugins: [
+    // ...
+    AutoImport({
+      resolvers: [TDesignResolver({
+        library: 'mobile-vue'
+      })],
+    }),
+    Components({
+      resolvers: [TDesignResolver({
+        library: 'mobile-vue'
+      })],
+    }),
+  ],
+};
+```
+
+#### Webpack
+
+```js
+const AutoImport = require('unplugin-auto-import/webpack');
+const Components = require('unplugin-vue-components/webpack');
+const { TDesignResolver } = require('unplugin-vue-components/resolvers');
+module.exports = {
+  // ...
+  plugins: [
+    AutoImport({
+      resolvers: [TDesignResolver({
+        library: 'mobile-vue'
+      })],
+    }),
+    Components({
+      resolvers: [TDesignResolver({
+        library: 'mobile-vue'
+      })],
+    }),
+  ],
+};
+```
+
+> `TDesignResolver` 支持的配置，可以点击此[链接](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/tdesign.ts#L4)。
+
 
 ## 浏览器兼容性
 
@@ -42,3 +158,14 @@ app.use(TDesign);
 详情参见[移动端组件库浏览器兼容性说明](https://github.com/Tencent/tdesign/wiki/Browser-Compatibility)
 
 
+## FAQ
+
+Q: 是否内置reset样式统一页面元素的默认样式 ？
+
+A: `0.25.0` 版本开始我们不再引入 `reset.less`。
+
+如果你的项目开发依赖于原先的 `reset` 样式，可以从 `dist` 目录中单独引入它：
+
+```js
+import 'tdesign-mobile-vue/dist/reset.css';
+```

--- a/site/mobile/main.ts
+++ b/site/mobile/main.ts
@@ -5,7 +5,6 @@ import DemoBlock from './components/demo-block.vue';
 import router from './router';
 
 import TDesign from '@/index';
-import '../../src/_common/style/mobile/_reset.less';
 import '../styles/mobile/index.less';
 
 createApp(app)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
### 🔗 相关 PR
common： [#1392](https://github.com/Tencent/tdesign-common/pull/1392)

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：按官网说明接入tdesign-mobile-vue，部分组件出现样式问题（Search\DateTimePicker等）。
原因：缺少 _reset.css文件
方案：将_reset.css 涉及的组件样式，全部迁移至组件本身。同时，单独导出 reset.css 到 dist 目录，支持从  `tdesign-mobile-vue/dist/reset.css` 中单独引入，存在不兼容更新。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- break: 默认移除全局 `reset.css` 样式引入，可从 `tdesign-mobile-vue/dist/reset.css` 中单独引入

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
