### PR TITLE
fix(swiper): dots-bar示例height设置问题

### DIFF
--- a/src/swiper/demos/custom.vue
+++ b/src/swiper/demos/custom.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="padding: 0 16px">
-    <t-swiper :autoplay="true" height="192" :navigation="{ type: 'dots-bar' }" @change="handleChange">
+    <t-swiper :autoplay="true" height="192px" :navigation="{ type: 'dots-bar' }" @change="handleChange">
       <t-swiper-item v-for="(item, index) in swiperList" :key="index">
         <img :src="item" class="img" />
       </t-swiper-item>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
官网示例无法显示
<img width="441" alt="image" src="https://github.com/Tencent/tdesign-mobile-vue/assets/13745660/80317112-23b6-4646-8be0-8b8ae429bd29">

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

排查是示例代码中height="192",  number应该是:height='192', string应该是height='192px'


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Swiper): 修复条状（dots-bar)示例中高度错误问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
