### PR TITLE
fix(Cascader): 修复 `change` 事件被触发两次和 `v-model` 没有响应式的问题

### DIFF
--- a/src/cascader/cascader.vue
+++ b/src/cascader/cascader.vue
@@ -218,8 +218,7 @@ export default defineComponent({
         childrenInfo.value = e;
         childrenInfo.level = level;
       } else {
-        setCascaderValue(item[(keys as Ref<KeysType>).value?.value ?? 'value']);
-        props.onChange?.(
+        setCascaderValue(
           item[(keys as Ref<KeysType>).value?.value ?? 'value'],
           items.map((item, index) => toRaw(item?.[selectedIndexes[index]])),
         );

--- a/src/shared/useVModel/index.ts
+++ b/src/shared/useVModel/index.ts
@@ -1,5 +1,4 @@
 import { ref, Ref, getCurrentInstance, ComponentInternalInstance } from 'vue';
-import kebabCase from 'lodash/kebabCase';
 
 export type ChangeHandler<T> = (value: T, ...args: any[]) => void;
 
@@ -11,20 +10,12 @@ export function useVModel<T>(
   propName = 'value',
   // emit 和 eventName 用于支持 v-model 和 xxx.sync 语法糖
 ): [Ref<T>, ChangeHandler<T>] {
-  const { emit, vnode } = getCurrentInstance() as ComponentInternalInstance;
+  const { emit } = getCurrentInstance() as ComponentInternalInstance;
   const internalValue = ref<T>() as Ref<T>;
   internalValue.value = defaultValue;
 
-  const vProps = vnode.props || {};
-  const isVM =
-    Object.prototype.hasOwnProperty.call(vProps, 'modelValue') ||
-    Object.prototype.hasOwnProperty.call(vProps, 'model-value');
-  const isVMP =
-    Object.prototype.hasOwnProperty.call(vProps, propName) ||
-    Object.prototype.hasOwnProperty.call(vProps, kebabCase(propName));
-
   // 受控模式 v-model:propName
-  if (isVMP) {
+  if (typeof value.value !== 'undefined') {
     return [
       value,
       (newValue, ...args) => {
@@ -35,7 +26,7 @@ export function useVModel<T>(
   }
 
   // 受控模式:modelValue v-model
-  if (isVM) {
+  if (typeof modelValue.value !== 'undefined') {
     return [
       modelValue,
       (newValue, ...args) => {

--- a/src/shared/useVModel/index.ts
+++ b/src/shared/useVModel/index.ts
@@ -1,4 +1,5 @@
 import { ref, Ref, getCurrentInstance, ComponentInternalInstance } from 'vue';
+import kebabCase from 'lodash/kebabCase';
 
 export type ChangeHandler<T> = (value: T, ...args: any[]) => void;
 
@@ -10,12 +11,20 @@ export function useVModel<T>(
   propName = 'value',
   // emit 和 eventName 用于支持 v-model 和 xxx.sync 语法糖
 ): [Ref<T>, ChangeHandler<T>] {
-  const { emit } = getCurrentInstance() as ComponentInternalInstance;
+  const { emit, vnode } = getCurrentInstance() as ComponentInternalInstance;
   const internalValue = ref<T>() as Ref<T>;
   internalValue.value = defaultValue;
 
+  const vProps = vnode.props || {};
+  const isVM =
+    Object.prototype.hasOwnProperty.call(vProps, 'modelValue') ||
+    Object.prototype.hasOwnProperty.call(vProps, 'model-value');
+  const isVMP =
+    Object.prototype.hasOwnProperty.call(vProps, propName) ||
+    Object.prototype.hasOwnProperty.call(vProps, kebabCase(propName));
+
   // 受控模式 v-model:propName
-  if (typeof value.value !== 'undefined') {
+  if (isVMP) {
     return [
       value,
       (newValue, ...args) => {
@@ -26,7 +35,7 @@ export function useVModel<T>(
   }
 
   // 受控模式:modelValue v-model
-  if (typeof modelValue.value !== 'undefined') {
+  if (isVM) {
     return [
       modelValue,
       (newValue, ...args) => {

--- a/src/shared/useVModel/index.ts
+++ b/src/shared/useVModel/index.ts
@@ -1,4 +1,5 @@
 import { ref, Ref, getCurrentInstance, ComponentInternalInstance } from 'vue';
+import kebabCase from 'lodash/kebabCase';
 
 export type ChangeHandler<T> = (value: T, ...args: any[]) => void;
 
@@ -10,12 +11,18 @@ export function useVModel<T>(
   propName = 'value',
   // emit 和 eventName 用于支持 v-model 和 xxx.sync 语法糖
 ): [Ref<T>, ChangeHandler<T>] {
-  const { emit } = getCurrentInstance() as ComponentInternalInstance;
+  const { emit, vnode } = getCurrentInstance() as ComponentInternalInstance;
   const internalValue = ref<T>() as Ref<T>;
   internalValue.value = defaultValue;
-
+  const vProps = vnode.props || {};
+  const isVM =
+    Object.prototype.hasOwnProperty.call(vProps, 'modelValue') ||
+    Object.prototype.hasOwnProperty.call(vProps, 'model-value');
+  const isVMP =
+    Object.prototype.hasOwnProperty.call(vProps, propName) ||
+    Object.prototype.hasOwnProperty.call(vProps, kebabCase(propName));
   // 受控模式 v-model:propName
-  if (typeof value.value !== 'undefined') {
+  if (isVMP || typeof value.value !== 'undefined') {
     return [
       value,
       (newValue, ...args) => {
@@ -26,7 +33,7 @@ export function useVModel<T>(
   }
 
   // 受控模式:modelValue v-model
-  if (typeof modelValue.value !== 'undefined') {
+  if (isVM || typeof modelValue.value !== 'undefined') {
     return [
       modelValue,
       (newValue, ...args) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1086 

### 💡 需求背景和解决方案

### 📝 更新日志

- fix(Cascader): 修复 `change` 事件被触发两次和 `v-model` 没有响应式的问题

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
