### PR TITLE
fix(Calendar): selected date not in view (#1043)

### DIFF
--- a/src/calendar/template.vue
+++ b/src/calendar/template.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ [`${name}`]: true, [`${name}--popup`]: usePopup }">
+  <div ref="templateRef" :class="{ [`${name}`]: true, [`${name}--popup`]: usePopup }">
     <div :class="`${name}__title`">
       <slot name="title">{{ title || '请选择日期' }}</slot>
     </div>
@@ -82,6 +82,7 @@ const getYearMonthDay = (date: Date) => {
 
 const title = computed(() => props.title);
 const usePopup = computed(() => props.usePopup);
+const templateRef = ref(null);
 const valueRef = ref(props.value);
 const selectedDate = ref();
 const firstDayOfWeek = computed(() => props.firstDayOfWeek || 0);
@@ -253,5 +254,6 @@ watch(
 );
 defineExpose({
   valueRef,
+  templateRef,
 });
 </script>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1043 

### 💡 需求背景和解决方案

背景： 由于日历展示区域是一个带滚动条的列表，默认滚动条在顶部，当用户传入的value不在日历的起始月份时，需要滚动才能找到设置的目标日期

方案：点开popup或日历加载时，手动将滚动条定位到value所属的月份

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Calendar): 日历选择器支持自动定位到选中日期

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
