### PR TITLE
fix(dropdownmenu): 改变label定义标题不起效

### DIFF
--- a/src/dropdown-menu/dropdown-menu.vue
+++ b/src/dropdown-menu/dropdown-menu.vue
@@ -66,8 +66,10 @@ export default defineComponent({
     // 通过 slots.default 子成员，计算标题栏选项
     const menuTitles = computed(() =>
       menuItems.value.map((item: any, index: number) => {
-        const { keys, label, value, disabled, options } = item.props;
-        const target = options?.find((item: any) => item[keys?.value ?? 'value'] === value);
+        const { keys, label, value, modelValue, defaultValue, disabled, options } = item.props;
+        const currentValue = value || modelValue || defaultValue;
+        const target = options?.find((item: any) => item[keys?.value ?? 'value'] === currentValue);
+
         if (state.itemsLabel.length < index + 1) {
           if (!label) {
             state.itemsLabel.push((target && target[keys?.label ?? 'label']) || '');
@@ -81,7 +83,7 @@ export default defineComponent({
           };
         }
         return {
-          label: menuTitles.value[index].label,
+          label: label || menuTitles.value[index].label,
           disabled: disabled !== undefined && disabled !== false,
         };
       }),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fix #1119 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
主要解决：
1. 多选时，通过label来控制标题不起效问题。
2. 单选时，v-model和defaultValue 初始化时没有标题的问题
    复现示例： https://stackblitz.com/edit/m5k9ia-xxbvmk?file=src%2Fdemo.vue

    
![image](https://github.com/Tencent/tdesign-mobile-vue/assets/13745660/c2d37e7d-ba02-4b70-bd79-9c2c0cae3537)



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dropdownMenu): 改变label控制标题不起效问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
