### PR TITLE
feat(cascader): 新增默认选项标签，可以自定义定制级联组件中“选择选项”文案

### DIFF
--- a/src/cascader/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/cascader/__test__/__snapshots__/demo.test.jsx.snap
@@ -108,7 +108,9 @@ exports[`Cascader > Cascader baseVue demo works fine 1`] = `
                 <div
                   class="t-cascader__step-label t-cascader__step-label--active"
                 >
+                  
                   选择选项
+                  
                 </div>
                 <svg
                   class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -336,7 +338,9 @@ exports[`Cascader > Cascader keysVue demo works fine 1`] = `
                 <div
                   class="t-cascader__step-label t-cascader__step-label--active"
                 >
+                  
                   选择选项
+                  
                 </div>
                 <svg
                   class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -564,7 +568,9 @@ exports[`Cascader > Cascader lazyVue demo works fine 1`] = `
                 <div
                   class="t-cascader__step-label t-cascader__step-label--active"
                 >
+                  
                   选择选项
+                  
                 </div>
                 <svg
                   class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -789,7 +795,9 @@ exports[`Cascader > Cascader mobileVue demo works fine 1`] = `
                     <div
                       class="t-cascader__step-label t-cascader__step-label--active"
                     >
+                      
                       选择选项
+                      
                     </div>
                     <svg
                       class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -1246,7 +1254,9 @@ exports[`Cascader > Cascader mobileVue demo works fine 1`] = `
                     <div
                       class="t-cascader__step-label t-cascader__step-label--active"
                     >
+                      
                       选择选项
+                      
                     </div>
                     <svg
                       class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -1487,7 +1497,9 @@ exports[`Cascader > Cascader mobileVue demo works fine 1`] = `
                     <div
                       class="t-cascader__step-label t-cascader__step-label--active"
                     >
+                      
                       选择选项
+                      
                     </div>
                     <svg
                       class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -1728,7 +1740,9 @@ exports[`Cascader > Cascader mobileVue demo works fine 1`] = `
                     <div
                       class="t-cascader__step-label t-cascader__step-label--active"
                     >
+                      
                       选择选项
+                      
                     </div>
                     <svg
                       class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -1973,7 +1987,9 @@ exports[`Cascader > Cascader mobileVue demo works fine 1`] = `
                     <div
                       class="t-cascader__step-label t-cascader__step-label--active"
                     >
+                      
                       选择选项
+                      
                     </div>
                     <svg
                       class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -2369,7 +2385,9 @@ exports[`Cascader > Cascader withTitleVue demo works fine 1`] = `
                 <div
                   class="t-cascader__step-label t-cascader__step-label--active"
                 >
+                  
                   选择选项
+                  
                 </div>
                 <svg
                   class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -2601,7 +2619,9 @@ exports[`Cascader > Cascader withValueVue demo works fine 1`] = `
                 <div
                   class="t-cascader__step-label t-cascader__step-label--active"
                 >
+                  
                   选择选项
+                  
                 </div>
                 <svg
                   class="t-icon t-icon-chevron-right t-cascader__step-arrow"

--- a/src/cascader/__test__/__snapshots__/index.test.jsx.snap
+++ b/src/cascader/__test__/__snapshots__/index.test.jsx.snap
@@ -60,7 +60,9 @@ exports[`cascader > events > : pick 1`] = `
               <div
                 class="t-cascader__step-label t-cascader__step-label--active"
               >
+                
                 选择选项
+                
               </div>
               <svg
                 class="t-icon t-icon-chevron-right t-cascader__step-arrow"

--- a/src/cascader/__test__/index.test.jsx
+++ b/src/cascader/__test__/index.test.jsx
@@ -158,6 +158,8 @@ const itemList = [
 
 const subTitles = ['请选择省份', '请选择城市', '请选择区/县'];
 
+const defaultPlaceholder = "默认选项标签";
+
 describe('cascader', () => {
   describe('props', () => {
     it(':visible	', async () => {
@@ -214,6 +216,12 @@ describe('cascader', () => {
       });
     });
 
+    it(': placeholder', async () => {
+      const wrapper = mount(<Cascader options={options} placeholder={defaultPlaceholder} />);
+      const $placeholder = wrapper.find(`.${name}__step-label`);
+      expect($placeholder.text()).toEqual(defaultPlaceholder);
+    });
+
     it(': subTitles', async () => {
       const wrapper = mount(<Cascader options={options} subTitles={subTitles} />);
       const $subTitles = wrapper.find(`.${name}__options-title`);
@@ -254,6 +262,16 @@ describe('cascader', () => {
       });
       const $title = wrapper.find(`.${name}__title`);
       expect($title.text()).toBe(title);
+    });
+
+    it(': placeholder', () => {
+      const wrapper = mount(<Cascader options={options} />, {
+        slots: {
+          placeholder: defaultPlaceholder,
+        },
+      });
+      const $placeholder = wrapper.find(`.${name}__step-label`);
+      expect($placeholder.text()).toBe(defaultPlaceholder);
     });
 
     it(': closeBtn', () => {

--- a/src/cascader/cascader.en-US.md
+++ b/src/cascader/cascader.en-US.md
@@ -15,7 +15,7 @@ title | String / Slot / Function | - | Typescript：`string \| TNode`。[see mor
 value | String / Number | - | `v-model` and `v-model:value` is supported | N
 defaultValue | String / Number | - | uncontrolled property | N
 visible | Boolean | false | \- | N
-placeholder | String / Slot / Function | 选择选项 | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
+placeholder | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 onChange | Function |  | Typescript：`(value: string \| number, selectedOptions: string[]) => void`<br/> | N
 onClose | Function |  | Typescript：`(trigger: TriggerSource) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/cascader/type.ts)。<br/>`type TriggerSource = 'overlay' \| 'close-btn' \| 'finish'`<br/> | N
 onPick | Function |  | Typescript：`(context: { level: number; value: string | number; index: number }) => void`<br/> | N

--- a/src/cascader/cascader.en-US.md
+++ b/src/cascader/cascader.en-US.md
@@ -15,6 +15,7 @@ title | String / Slot / Function | - | Typescript：`string \| TNode`。[see mor
 value | String / Number | - | `v-model` and `v-model:value` is supported | N
 defaultValue | String / Number | - | uncontrolled property | N
 visible | Boolean | false | \- | N
+placeholder | String / Slot / Function | 选择选项 | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 onChange | Function |  | Typescript：`(value: string \| number, selectedOptions: string[]) => void`<br/> | N
 onClose | Function |  | Typescript：`(trigger: TriggerSource) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/cascader/type.ts)。<br/>`type TriggerSource = 'overlay' \| 'close-btn' \| 'finish'`<br/> | N
 onPick | Function |  | Typescript：`(context: { level: number; value: string | number; index: number }) => void`<br/> | N

--- a/src/cascader/cascader.md
+++ b/src/cascader/cascader.md
@@ -14,6 +14,7 @@ title | String / Slot / Function | - | 标题。TS 类型：`string \| TNode`。
 value | String / Number | - | 选项值。支持语法糖 `v-model` 或 `v-model:value` | N
 defaultValue | String / Number | - | 选项值。非受控属性 | N
 visible | Boolean | false | 是否展示 | N
+placeholder | String / Slot / Function | 选择选项 | 未选中时的提示文案。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 onChange | Function |  | TS 类型：`(value: string \| number, selectedOptions: string[]) => void`<br/>值发生变更时触发 | N
 onClose | Function |  | TS 类型：`(trigger: TriggerSource) => void`<br/>关闭时触发。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/cascader/type.ts)。<br/>`type TriggerSource = 'overlay' \| 'close-btn' \| 'finish'`<br/> | N
 onPick | Function |  | TS 类型：`(context: { level: number, value: string \| number, index: number }) => void`<br/>选择后触发 | N

--- a/src/cascader/props.ts
+++ b/src/cascader/props.ts
@@ -53,6 +53,10 @@ export default {
   defaultValue: {
     type: [String, Number] as PropType<TdCascaderProps['defaultValue']>,
   },
+  /** 未选中时的提示文案 */
+  placeholder: {
+    type: [String, Function] as PropType<TdCascaderProps['placeholder']>,
+  },
   /** 是否展示 */
   visible: Boolean,
   /** 值发生变更时触发 */

--- a/src/cascader/type.ts
+++ b/src/cascader/type.ts
@@ -53,6 +53,10 @@ export interface TdCascaderProps<CascaderOption extends TreeOptionData = TreeOpt
    */
   visible?: boolean;
   /**
+   * 未选中时的提示文案
+   */
+  placeholder?: string | TNode;
+  /**
    * 值发生变更时触发
    */
   onChange?: (value: string | number, selectedOptions: string[]) => void;

--- a/src/form/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/form/__test__/__snapshots__/demo.test.jsx.snap
@@ -879,7 +879,9 @@ exports[`Form > Form horizontalVue demo works fine 1`] = `
                         <div
                           class="t-cascader__step-label t-cascader__step-label--active"
                         >
+                          
                           选择选项
+                          
                         </div>
                         <svg
                           class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -2608,7 +2610,9 @@ exports[`Form > Form mobileVue demo works fine 1`] = `
                               <div
                                 class="t-cascader__step-label t-cascader__step-label--active"
                               >
+                                
                                 选择选项
+                                
                               </div>
                               <svg
                                 class="t-icon t-icon-chevron-right t-cascader__step-arrow"
@@ -4197,7 +4201,9 @@ exports[`Form > Form verticalVue demo works fine 1`] = `
                         <div
                           class="t-cascader__step-label t-cascader__step-label--active"
                         >
+                          
                           选择选项
+                          
                         </div>
                         <svg
                           class="t-icon t-icon-chevron-right t-cascader__step-arrow"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #1130

### 💡 需求背景和解决方案

给cascader组件新增一个 placeholder 参数，并且修改对应文档，以及添加测试用例。

### 📝 更新日志

- feat(Cascader): 新增 `placeholder` 属性，支持自定义未选中时的提示文案
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
