### PR TITLE
fix(swipe-cell): 修复t-swipe-cell 在 t-popup 中无法左右滑动

### DIFF
--- a/src/swipe-cell/swipe-cell.vue
+++ b/src/swipe-cell/swipe-cell.vue
@@ -181,6 +181,7 @@ export default defineComponent({
         if (props.disabled) {
           return;
         }
+        setPanelWidth();
         swipeDir = 0;
         initData.moved = false;
         initData.offset = initData.pos;
@@ -231,12 +232,16 @@ export default defineComponent({
       },
     });
 
-    const classes = computed(() => [`${name}`]);
-    onMounted(() => {
+    const setPanelWidth = () => {
       const leftWidth = leftRef.value?.clientWidth as number;
       const rightWidth = rightRef.value?.clientWidth as number;
       initData.leftWidth = leftWidth > 0 ? leftWidth : 0;
       initData.rightWidth = rightWidth > 0 ? rightWidth : 0;
+    };
+
+    const classes = computed(() => [`${name}`]);
+    onMounted(async () => {
+      setPanelWidth();
       renderMenuStatus();
     });
     onUnmounted(() => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #1055

### 💡 需求背景和解决方案

1. `t-swipe-cell` 在 `t-popup` 中无法左右滑动，经过检查，是因为`t-swipe-cell` 在`onMounted`时获取内容宽度，而`t-popup`中使用`display: none;`对元素进行隐藏，在元素隐藏时无法获取到内容的宽度，导致后续设置移动距离为**0**，经过尝试，修改`t-popup`为`visibility:hidden`进行隐藏，但这样通过修改其他组件达到的效果不足以覆盖所有类似场景，于是在`t-swipe-cell` 中的`onSwipeStart`方法开始时重新获取宽度。

<img width="451" alt="image" src="https://github.com/Tencent/tdesign-mobile-vue/assets/40658369/95aff7fa-bcff-4ed1-bbb0-67a5b10e1547">


### 📝 更新日志

- fix(swipe-cell): 修复t-swipe-cell在t-popup中无法左右滑动

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供