### PR TITLE
fix(dropdown-menu): 修复DropdownItem组件不受控

### DIFF
--- a/src/dropdown-menu/dropdown-menu.vue
+++ b/src/dropdown-menu/dropdown-menu.vue
@@ -69,21 +69,19 @@ export default defineComponent({
         const { keys, label, value, modelValue, defaultValue, disabled, options } = item.props;
         const currentValue = value || modelValue || defaultValue;
         const target = options?.find((item: any) => item[keys?.value ?? 'value'] === currentValue);
-
         if (state.itemsLabel.length < index + 1) {
-          if (!label) {
-            state.itemsLabel.push((target && target[keys?.label ?? 'label']) || '');
-          } else {
-            state.itemsLabel.push(label || '');
-          }
-          const computedLabel = target?.[keys?.label ?? 'label'] || '';
+          const targetLabel = (target && target[keys?.label ?? 'label']) || '';
+          const computedLabel = label || targetLabel;
+
+          state.itemsLabel.push(computedLabel);
+
           return {
-            label: label || computedLabel,
+            label: computedLabel,
             disabled: disabled !== undefined && disabled !== false,
           };
         }
         return {
-          label: label || menuTitles.value[index].label,
+          label: label || target.label,
           disabled: disabled !== undefined && disabled !== false,
         };
       }),
@@ -124,6 +122,7 @@ export default defineComponent({
       }
       props.onMenuOpened?.('menuOpened');
       state.activeId = idx;
+      state.itemsLabel[idx] = item.label;
 
       // 获取菜单定位
       const bar = refBar.value as any;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1139

### 💡 需求背景和解决方案

`dropdown-item`不受控，排查发现问题出在`dropdown-menu`组件，没有及时更新，是因为在监听变化后返回了自身的`label`

```js
label: label || menuTitles.value[index].label
```

不清楚为什么要使用自身的`label`，在上方已经有获取到的目标，就修改了取`menuTitles`改为了`target`，修复了动态修改没更新的问题。

```js
const target = options?.find((item: any) => item[keys?.value ?? 'value'] === currentValue);
```

另外一个问题是展开和收缩之后，又自动修改回原来的`label`了，排查发现在展开时，没有重新赋值给`state`，于是添加了

```js
state.itemsLabel[idx] = item.label;
```

### 📝 更新日志

- fix(DropdownMenu): 解决 `DropdownItem` 组件的 `label` 属性不受控

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

