### PR TITLE
fix(tabs): keep-alive下tabs蓝线样式问题

### DIFF
--- a/src/tabs/tabs.vue
+++ b/src/tabs/tabs.vue
@@ -59,6 +59,7 @@ import {
   Fragment,
   watch,
   CSSProperties,
+  onActivated,
 } from 'vue';
 import config from '../config';
 import TabsProps from './props';
@@ -174,6 +175,9 @@ export default defineComponent({
     });
     onBeforeUnmount(() => {
       window.removeEventListener('resize', moveToActiveTab);
+    });
+    onActivated(() => {
+      moveToActiveTab();
     });
 
     watch(value, () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://stackblitz.com/~/github.com/574400391/t-tabs-demo

安卓手机在keep-alive下的tabs路由，若跳转下一页点击输入框弹出软键盘后再返回tabs选项卡页面，选项卡的下划线会停留在最左侧。


https://github.com/Tencent/tdesign-mobile-vue/assets/13745660/2831e8fc-97bf-4afa-bfb7-8fff0c785b07



### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在onActivated中重新计算蓝线样式

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复组件在 `keep-alive` 下底部激活态蓝线样式位置错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
