### PR TITLE
feat(textarea): 响应式地触发 autosize 样式计算

### DIFF
--- a/src/textarea/textarea.vue
+++ b/src/textarea/textarea.vue
@@ -52,7 +52,6 @@ export default defineComponent({
     const textareaLength = ref(0);
     const { value, modelValue } = toRefs(props);
     const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
-    const propsAutosize = computed(() => props.autosize);
     const textareaClass = computed(() => [
       `${componentName}`,
       {
@@ -85,6 +84,8 @@ export default defineComponent({
     const adjustTextareaHeight = () => {
       if (props.autosize === true) {
         textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement);
+      } else if (props.autosize === false) {
+        textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement, 1, 1);
       } else if (typeof props.autosize === 'object') {
         const { minRows, maxRows } = props.autosize;
         textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement, minRows, maxRows);
@@ -144,18 +145,12 @@ export default defineComponent({
         adjustTextareaHeight();
       });
     });
-    watch(propsAutosize, (value) => {
-      switch (value) {
-        case true:
-          textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement);
-          break;
-        case false:
-          textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement, 1, 1);
-          break;
-        default:
-          break;
-      }
-    });
+    watch(
+      () => props.autosize,
+      () => {
+        adjustTextareaHeight();
+      },
+    );
     return {
       componentName,
       ...toRefs(props),

--- a/src/textarea/textarea.vue
+++ b/src/textarea/textarea.vue
@@ -52,7 +52,7 @@ export default defineComponent({
     const textareaLength = ref(0);
     const { value, modelValue } = toRefs(props);
     const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
-
+    const propsAutosize = computed(() => props.autosize);
     const textareaClass = computed(() => [
       `${componentName}`,
       {
@@ -143,6 +143,18 @@ export default defineComponent({
       nextTick(() => {
         adjustTextareaHeight();
       });
+    });
+    watch(propsAutosize, (value) => {
+      switch (value) {
+        case true:
+          textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement);
+          break;
+        case false:
+          textareaStyle.value = calcTextareaHeight(textareaRef.value as HTMLTextAreaElement, 1, 1);
+          break;
+        default:
+          break;
+      }
     });
     return {
       componentName,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在移动端/小屏幕可能存在以下场景：

textarea 会被 Sticky 之类的组件始终固定在页面，假如输入的内容过多，会需要使用 autosize 的功能，方便编辑和查看。但假如离开了 textarea 则想关闭 autosize 的功能，恢复到默认的 `calcTextareaHeight(textareaRef.value as HTMLTextAreaElement, 1, 1);` 高度，以获得更多空间显示其他内容。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Textarea): 支持 `autosize` 属性值变更后输入框高度重新计算

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
