### PR TITLE
fix(sticky): getCurrentInstance在computed中获取不到

### DIFF
--- a/src/sticky/sticky.vue
+++ b/src/sticky/sticky.vue
@@ -21,8 +21,8 @@ export default defineComponent({
   props,
   setup(props) {
     const boxClasses = name;
-    const stickyContent = computed(() => renderContent(getCurrentInstance(), 'default', ''));
-
+    const internalInstance = getCurrentInstance();
+    const stickyContent = computed(() => renderContent(internalInstance, 'default', ''));
     // box 用于占位和记录边界
     // content 用于实际定位
     const boxRef = templateRef<HTMLElement | null>('boxRef', null);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

1.0.9版本tabs示例无法显示问题排查，发现是sticky组件问题
![image](https://github.com/Tencent/tdesign-mobile-vue/assets/13745660/8b9d7738-59e0-44f1-b106-97b91c7e965f)


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

排查发现是是sticky组件问题。

在1.0.9版本还未锁vue版本时，最新获取的依赖中，sticky组件中 ：

const stickyContent = computed(() => renderContent(getCurrentInstance(), 'default', ''));

getCurrentInstance在computed中获取不到了


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Sticky):  修复 `getCurrentInstance` 在 `computed` 中无法获取元素的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
