### PR TITLE
fix(form): add param named firstError

### DIFF
--- a/src/form/demos/horizontal.vue
+++ b/src/form/demos/horizontal.vue
@@ -288,8 +288,8 @@ const onSubmit = (e: any) => {
 };
 
 const rules = {
-  name: [{ validator: (val: any) => val === 8, message: '只能输入8个字符英文' }],
-  password: [{ validator: (val: any) => val > 6, message: '长度大于6个字符' }],
+  name: [{ validator: (val: any) => val.length === 8, message: '只能输入8个字符英文' }],
+  password: [{ validator: (val: any) => val.length > 6, message: '长度大于6个字符' }],
   gender: [{ validator: (val: any) => val !== '', message: '不能为空' }],
   birth: [{ validator: (val: any) => val !== '', message: '不能为空' }],
   place: [{ validator: (val: any) => val !== '', message: '不能为空' }],

--- a/src/form/demos/vertical.vue
+++ b/src/form/demos/vertical.vue
@@ -275,8 +275,8 @@ const onSubmit = (e: any) => {
 };
 
 const rules = {
-  name: [{ validator: (val: any) => val === 8, message: '只能输入8个字符英文' }],
-  password: [{ validator: (val: any) => val > 6, message: '长度大于6个字符' }],
+  name: [{ validator: (val: any) => val.length === 8, message: '只能输入8个字符英文' }],
+  password: [{ validator: (val: any) => val.length > 6, message: '长度大于6个字符' }],
   gender: [{ validator: (val: any) => val !== '', message: '不能为空' }],
   birth: [{ validator: (val: any) => val !== '', message: '不能为空' }],
   place: [{ validator: (val: any) => val !== '', message: '不能为空' }],

--- a/src/form/form.vue
+++ b/src/form/form.vue
@@ -8,6 +8,7 @@
 import { computed, defineComponent, provide, reactive, ref, toRefs } from 'vue';
 import isEmpty from 'lodash/isEmpty';
 import isArray from 'lodash/isArray';
+import isBoolean from 'lodash/isBoolean';
 import isFunction from 'lodash/isFunction';
 import {
   Data,
@@ -117,14 +118,22 @@ export default defineComponent({
       return result;
     };
 
+    const getFirstError = (r: Result) => {
+      if (isBoolean(r)) return '';
+      return r?.[Object.keys(r)?.[0]]?.[0]?.message || '';
+    };
     const submitParams = ref<Pick<FormValidateParams, 'showErrorMessage'>>();
     const onSubmit = (e?: FormSubmitEvent) => {
       if (props.preventSubmitDefault && e) {
         preventDefault(e, true);
       }
       validate(submitParams.value).then((r) => {
+        const firstError = getFirstError(r);
         // @ts-ignore
-        props.onSubmit?.({ validateResult: r });
+        props.onSubmit?.({
+          validateResult: r,
+          firstError,
+        });
       });
       submitParams.value = undefined;
     };

--- a/src/form/form.vue
+++ b/src/form/form.vue
@@ -66,6 +66,12 @@ export default defineComponent({
     // @ts-ignore
     const formRef = ref<HTMLFormElement>(null);
     const children = ref<FormItemContext[]>([]);
+    const sortedValidateResult = ref<FormItemValidateResult<Data>[]>([]);
+    const getFirstErr = (): (() => string | null) => {
+      const first = sortedValidateResult.value?.[0];
+      if (!first) return null;
+      return first[Object.keys(first)?.[0]]?.[0]?.message;
+    };
 
     provide<FormDisabledProvider>('formDisabled', {
       disabled,
@@ -109,22 +115,25 @@ export default defineComponent({
       const list = children.value
         .filter((child) => isFunction(child.validate) && needValidate(String(child.name), fields))
         .map((child) => child.validate(trigger, showErrorMessage));
-      const arr = await Promise.all(list);
-      const result = formatValidateResult(arr);
+      sortedValidateResult.value = await Promise.all(list);
+      const result = formatValidateResult(sortedValidateResult.value);
       props.onValidate?.({
         validateResult: result,
       });
       return result;
     };
-
     const submitParams = ref<Pick<FormValidateParams, 'showErrorMessage'>>();
     const onSubmit = (e?: FormSubmitEvent) => {
       if (props.preventSubmitDefault && e) {
         preventDefault(e, true);
       }
       validate(submitParams.value).then((r) => {
+        const firstError = getFirstErr();
         // @ts-ignore
-        props.onSubmit?.({ validateResult: r });
+        props.onSubmit?.({
+          validateResult: r,
+          ...(firstError ? { firstError } : {}),
+        });
       });
       submitParams.value = undefined;
     };


### PR DESCRIPTION
form组件onSubmit回调补充firstError参数

fix #1302

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1302

### 💡 需求背景和解决方案

onSubmit参数对齐使用文档:
> TS 类型：(context: SubmitContext<FormData>) => void
> 表单提交时触发。其中 context.validateResult 表示校验结果，context.firstError 表示校验不通过的第一个规则提醒。
> context.validateResult 值为 true 表示校验通过；如果校验不通过，context.validateResult 值为校验结果列表。

<!--
1. 要解决的具体问题。
4. 列出最终的 API 实现和用法。
5. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): `submit` 事件补齐 `firstError` 参数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
