### PR TITLE
feat(Swiper): add two new informal event funs

### DIFF
--- a/src/swiper/swiper.tsx
+++ b/src/swiper/swiper.tsx
@@ -17,7 +17,7 @@ const navName = `${prefix}-swiper-nav`;
 export default defineComponent({
   name,
   props,
-  emits: ['change', 'update:current', 'update:modelValue'],
+  emits: ['change', 'update:current', 'update:modelValue', 'transitionenter', 'transitionleave'],
   setup(props, context) {
     const swiperClass = usePrefixClass('swiper');
     const readerTNodeJSX = useTNodeJSX();
@@ -175,6 +175,14 @@ export default defineComponent({
       startAutoplay();
     };
 
+    const onTransitionstart = (event: TransitionEvent) => {
+      context.emit('transitionenter', event);
+    };
+
+    const onTransitionend = (event: TransitionEvent) => {
+      context.emit('transitionleave', event);
+    };
+
     const addChild = (item: any) => {
       items.value.push(item);
     };
@@ -319,8 +327,10 @@ export default defineComponent({
               transform: translateContainer.value,
               height: containerHeight.value,
             }}
+            onTransitionstart={onTransitionstart}
             onTransitionend={(event: TransitionEvent) => {
               if (event.target === event.currentTarget) {
+                onTransitionend(event);
                 handleAnimationEnd();
               }
             }}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：目前 swiper 仅提供 change 和 click 事件，change 事件的触发时机是拖动后，click事件是点击时（两个事件触发时，动画实际还未完成），为方便用护在动画完成后在触发其他事件，新增  transitionenter 和 transitionleave 两个事件。（这两个事件名称和参数可能存在变更，是非正式的，因此暂时不在API文档中暴露，仅在组件内部支持。）

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Swiper): 新增 `transitionenter` 和 `transitionleave` 两个事件

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
