### PR TITLE
fix: 修复默认导入引用文件缺失问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tdesign"
   ],
   "title": "tdesign-mobile-vue",
-  "main": "lib/index-lib.js",
+  "main": "cjs/index-lib.js",
   "module": "es/index.js",
   "typings": "es/index.d.ts",
   "unpkg": "dist/tdesign.min.js",

--- a/src/components.ts
+++ b/src/components.ts
@@ -72,9 +72,3 @@ export * from './toast';
 
 // 全局配置
 export * from './config-provider';
-
-// 兼容原使用方式（2.x 移除）
-export { default as Dialog } from './dialog';
-export { default as ActionSheet } from './action-sheet';
-export { default as Message } from './message';
-export { default as Toast } from './toast';

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -8,7 +8,7 @@ import './style';
 
 export type DialogType = 'alert' | 'confirm' | 'show';
 
-export const DialogPropsDefault = {
+const DialogPropsDefault = {
   title: '',
   content: '',
   confirmBtn: '',

--- a/src/index-lib.ts
+++ b/src/index-lib.ts
@@ -1,3 +1,6 @@
+import './style';
+import tdesign from './index';
+
 const ENV = process.env.NODE_ENV;
 if (
   ENV !== 'test' &&
@@ -11,3 +14,4 @@ if (
 }
 
 export * from './index';
+export default tdesign;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,5 @@ const version = typeof __VERSION__ === 'undefined' ? '' : __VERSION__;
 export { install, version };
 export * from './plugins';
 export * from './components';
+export * from './common';
 export default { install, version };

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -3,3 +3,9 @@ export { MessagePlugin } from './message';
 export { ToastPlugin } from './toast';
 export { DrawerPlugin } from './drawer';
 export { LoadingPlugin } from './loading';
+
+// 兼容原使用方式（2.x 移除）
+export { default as Dialog } from './dialog';
+export { default as ActionSheet } from './action-sheet';
+export { default as Message } from './message';
+export { default as Toast } from './toast';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1487
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

问题1：默认导入时，引用文件缺失
方案参考： https://github.com/Tencent/tdesign-vue-next/pull/1685

问题2: 控制台告警
[Vue warn]: Plugin has already been applied to target app.
[Vue warn]: A plugin must either be a function or an object with an "install" function.
方案：“兼容原使用方式”的导出内容迁移到 plugin.ts 文件中，跳过app.use()重复引入的问题

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
