### PR TITLE
chore: upgrade tdesign-icons-vue-next 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@vueuse/core": "10.7.0",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
-    "tdesign-icons-vue-next": "^0.2.4",
+    "tdesign-icons-vue-next": "^0.2.5",
     "validator": "^13.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@vueuse/core": "10.7.0",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
-    "tdesign-icons-vue-next": "^0.2.5",
+    "tdesign-icons-vue-next": "^0.2.6",
     "validator": "^13.5.1"
   },
   "peerDependencies": {

--- a/src/cell/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/cell/__test__/__snapshots__/demo.test.jsx.snap
@@ -24,10 +24,8 @@ exports[`Cell > Cell groupVue demo works fine 1`] = `
             width="1em"
           >
             <path
-              clip-rule="evenodd"
-              d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+              d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
               fill="currentColor"
-              fill-rule="evenodd"
             />
           </svg>
         </div>
@@ -453,10 +451,8 @@ exports[`Cell > Cell mobileVue demo works fine 1`] = `
                   width="1em"
                 >
                   <path
-                    clip-rule="evenodd"
-                    d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+                    d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
                     fill="currentColor"
-                    fill-rule="evenodd"
                   />
                 </svg>
               </div>
@@ -777,10 +773,8 @@ exports[`Cell > Cell mobileVue demo works fine 1`] = `
                   width="1em"
                 >
                   <path
-                    clip-rule="evenodd"
-                    d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+                    d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
                     fill="currentColor"
-                    fill-rule="evenodd"
                   />
                 </svg>
                 
@@ -1058,10 +1052,8 @@ exports[`Cell > Cell mobileVue demo works fine 1`] = `
                   width="1em"
                 >
                   <path
-                    clip-rule="evenodd"
-                    d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+                    d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
                     fill="currentColor"
-                    fill-rule="evenodd"
                   />
                 </svg>
               </div>
@@ -1472,10 +1464,8 @@ exports[`Cell > Cell multipleVue demo works fine 1`] = `
             width="1em"
           >
             <path
-              clip-rule="evenodd"
-              d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+              d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
               fill="currentColor"
-              fill-rule="evenodd"
             />
           </svg>
           
@@ -1945,10 +1935,8 @@ exports[`Cell > Cell singleVue demo works fine 1`] = `
             width="1em"
           >
             <path
-              clip-rule="evenodd"
-              d="M12 3a4 4 0 00-4 4v3h8V7a4 4 0 00-4-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12v8h13v-8h-13zM9 15h6v2H9v-2z"
+              d="M12 3a4 4 0 014 4v3H8V7a4 4 0 014-4zm6 7V7A6 6 0 006 7v3H3.5v12h17V10H18zM5.5 12h13v8h-13v-8zM9 15h6v2H9v-2z"
               fill="currentColor"
-              fill-rule="evenodd"
             />
           </svg>
         </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Icon):  更新图标库版本到 0.2.6 ，`lock-on`  图标存在更新

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
