### PR TITLE
docs(collapse-panel): 修复在已经打开的面板时，修改了内容导致高度改变后面板显示有问题

### DIFF
--- a/src/collapse/collapse-panel.tsx
+++ b/src/collapse/collapse-panel.tsx
@@ -61,15 +61,16 @@ export default defineComponent({
           wrapperHeight.value = `${headHeight}px`;
           return;
         }
-        const { height: bodyHeight } = bodyRef.value.getBoundingClientRect();
-        const height = headHeight + bodyHeight;
-        wrapperHeight.value = `${height}px`;
+        setContentWrapperHeight();
       });
     };
 
     watch(
       isActive,
       () => {
+        if (wrapperHeight.value === 'auto') {
+          setContentWrapperHeight();
+        }
         nextTick(() => updatePanelState());
       },
       {
@@ -108,13 +109,31 @@ export default defineComponent({
       );
     };
 
+    const setContentWrapperHeight = () => {
+      const { height: headHeight } = headRef.value.getBoundingClientRect();
+      const { height: bodyHeight } = bodyRef.value.getBoundingClientRect();
+      const height = headHeight + bodyHeight;
+      wrapperHeight.value = `${height}px`;
+    };
+
+    const onTransitionEnd = () => {
+      if (isActive.value) {
+        wrapperHeight.value = 'auto';
+      }
+    };
+
     return () => {
       const headerContent = renderTNodeJSX('header');
       const noteContent = renderTNodeJSX('headerRightContent');
       const leftIcon = renderTNodeJSX('headerLeftIcon');
 
       return (
-        <div ref={wrapRef} class={rootClass.value} style={{ height: wrapperHeight.value }}>
+        <div
+          ref={wrapRef}
+          class={rootClass.value}
+          style={{ height: wrapperHeight.value }}
+          onTransitionend={onTransitionEnd}
+        >
           <div ref={headRef} class={`${componentName.value}__title`} onClick={handleClick}>
             <TCell
               class={[


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景 ：
在打开面板后假如里面的内容变多或者变少，都会导致显示有问题 所以要在打开面板后 让高度自适应 就可以避免后续更改了面板导致高度改变
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CollapsePanel): 修复面板在展开态时，面板内容变更时显示异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
