### PR TITLE
fix(indexes): 修复索引为数字字符串时侧边栏不能正常激活的问题

### DIFF
--- a/src/indexes/demos/custom.vue
+++ b/src/indexes/demos/custom.vue
@@ -57,6 +57,7 @@ const change = (index: number | string) => {
 <style lang="less">
 .component-wrap {
   height: calc(100vh - 50px);
+  background-color: #fff;
 }
 
 .capsule {
@@ -65,7 +66,7 @@ const change = (index: number | string) => {
   height: 30px;
   border-radius: 15px;
   background-color: #f3f3f3;
-  padding-left: 32rpx;
+  padding-left: 16px;
   display: flex;
   align-items: center;
   font-size: 14px;

--- a/src/indexes/indexes.en-US.md
+++ b/src/indexes/indexes.en-US.md
@@ -6,7 +6,7 @@
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-indexList | Array | - | Typescript：`(string \| number)[]` | N
+indexList | Array | - | Typescript：`Array<string \| number>` | N
 sticky | Boolean | true | Typescript：`Boolean` | N
 stickyOffset | Number | 0 | \- | N
 onChange | Function |  | Typescript：`(index: string \| number) => void`<br/> | N

--- a/src/indexes/indexes.en-US.md
+++ b/src/indexes/indexes.en-US.md
@@ -6,7 +6,7 @@
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-indexList | Array | - | Typescript：`string [] \| number[]` | N
+indexList | Array | - | Typescript：`(string \| number)[]` | N
 sticky | Boolean | true | Typescript：`Boolean` | N
 stickyOffset | Number | 0 | \- | N
 onChange | Function |  | Typescript：`(index: string \| number) => void`<br/> | N

--- a/src/indexes/indexes.md
+++ b/src/indexes/indexes.md
@@ -6,7 +6,7 @@
 
 名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
-indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`string [] \| number[]` | N
+indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`(string \| number)[]` | N
 sticky | Boolean | true | 索引是否吸顶，默认为true。TS 类型：`Boolean` | N
 stickyOffset | Number | 0 | 锚点吸顶时与顶部的距离	 | N
 onChange | Function |  | TS 类型：`(index: string \| number) => void`<br/>索引发生变更时触发事件 | N

--- a/src/indexes/indexes.md
+++ b/src/indexes/indexes.md
@@ -6,7 +6,7 @@
 
 名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
-indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`(string \| number)[]` | N
+indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`Array<string \| number>` | N
 sticky | Boolean | true | 索引是否吸顶，默认为true。TS 类型：`Boolean` | N
 stickyOffset | Number | 0 | 锚点吸顶时与顶部的距离	 | N
 onChange | Function |  | TS 类型：`(index: string \| number) => void`<br/>索引发生变更时触发事件 | N

--- a/src/indexes/indexes.tsx
+++ b/src/indexes/indexes.tsx
@@ -97,7 +97,9 @@ export default defineComponent({
             wrapper.classList.add(`${wrapperClass}--sticky`);
             wrapper.classList.add(`${wrapperClass}--active`);
             header.classList.add(`${headerClass}--active`);
-            wrapper.style = `transform: translate3d(0, ${betwixt ? offset : 0}px, 0); top: ${stickyTop}px;`;
+            wrapper.style = `transform: translate3d(0, ${
+              betwixt ? offset - groupTop[index].height : 0
+            }px, 0); top: ${stickyTop}px;`;
           } else {
             wrapper.classList.remove(`${wrapperClass}--sticky`);
             wrapper.classList.remove(`${wrapperClass}--active`);

--- a/src/indexes/type.ts
+++ b/src/indexes/type.ts
@@ -8,7 +8,7 @@ export interface TdIndexesProps {
   /**
    * 索引字符列表。不传默认 `A-Z`
    */
-  indexList?: string[] | number[];
+  indexList?: (string | number)[];
   /**
    * 索引是否吸顶，默认为true
    * @default true

--- a/src/indexes/type.ts
+++ b/src/indexes/type.ts
@@ -8,7 +8,7 @@ export interface TdIndexesProps {
   /**
    * 索引字符列表。不传默认 `A-Z`
    */
-  indexList?: (string | number)[];
+  indexList?: Array<string | number>;
   /**
    * 索引是否吸顶，默认为true
    * @default true


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(indexes): 修复索引为数字字符串时侧边栏不能正常激活，并优化索引吸顶时锚点切换效果 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
