### PR TITLE
feat(Radio): support readonly

### DIFF
--- a/src/radio/props.ts
+++ b/src/radio/props.ts
@@ -80,7 +80,10 @@ export default {
     },
   },
   /** 只读状态 */
-  readonly: Boolean,
+  readonly: {
+    type: Boolean,
+    default: undefined,
+  },
   /** 单选按钮的值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdRadioProps['value']>,

--- a/src/radio/props.ts
+++ b/src/radio/props.ts
@@ -79,6 +79,8 @@ export default {
       return ['left', 'right'].includes(val);
     },
   },
+  /** 只读状态 */
+  readonly: Boolean,
   /** 单选按钮的值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdRadioProps['value']>,

--- a/src/radio/radio-group-props.ts
+++ b/src/radio/radio-group-props.ts
@@ -57,6 +57,6 @@ export default {
   defaultValue: {
     type: [String, Number, Boolean] as PropType<TdRadioGroupProps['defaultValue']>,
   },
-  /** 选中值发生变化时触发 */
+  /** 选中值发生变化时触发, `context.name` 指 RadioGroup 的 name 属性 */
   onChange: Function as PropType<TdRadioGroupProps['onChange']>,
 };

--- a/src/radio/radio-group.tsx
+++ b/src/radio/radio-group.tsx
@@ -35,11 +35,11 @@ export default defineComponent({
         return opt;
       });
     });
-    const handleRadioChange = (val: RadioValue, e: Event) => {
+    const handleRadioChange = (val: RadioValue, context: { e: Event; name?: string }) => {
       if (props.allowUncheck && val === groupValue.value) {
-        setGroupValue('', { e });
+        setGroupValue('', context);
       } else {
-        setGroupValue(val, { e });
+        setGroupValue(val, context);
       }
     };
 

--- a/src/radio/radio.en-US.md
+++ b/src/radio/radio.en-US.md
@@ -21,7 +21,7 @@ maxContentRow | Number | 5 | \- | N
 maxLabelRow | Number | 3 | \- | N
 name | String | - | \- | N
 placement | String | left | options: left/right | N
-readonly | Boolean | false | \- | N
+readonly | Boolean | undefined | \- | N
 value | String / Number / Boolean | undefined | Typescript：`T` | N
 onChange | Function |  | Typescript：`(checked: boolean, context: { e: Event }) => void`<br/> | N
 

--- a/src/radio/radio.en-US.md
+++ b/src/radio/radio.en-US.md
@@ -21,7 +21,8 @@ maxContentRow | Number | 5 | \- | N
 maxLabelRow | Number | 3 | \- | N
 name | String | - | \- | N
 placement | String | left | options: left/right | N
-value | String / Number / Boolean | undefined | Typescript：`string \| number \| boolean` | N
+readonly | Boolean | false | \- | N
+value | String / Number / Boolean | undefined | Typescript：`T` | N
 onChange | Function |  | Typescript：`(checked: boolean, context: { e: Event }) => void`<br/> | N
 
 ### Radio Events
@@ -45,13 +46,13 @@ options | Array | - | Typescript：`Array<RadioOption>` `type RadioOption = stri
 placement | String | left | options: left/right | N
 value | String / Number / Boolean | - | `v-model` and `v-model:value` is supported。Typescript：`T` `type RadioValue = string \| number \| boolean`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/radio/type.ts) | N
 defaultValue | String / Number / Boolean | - | uncontrolled property。Typescript：`T` `type RadioValue = string \| number \| boolean`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/radio/type.ts) | N
-onChange | Function |  | Typescript：`(value: T, context: { e: Event }) => void`<br/> | N
+onChange | Function |  | Typescript：`(value: T, context: { e: Event; name?:string }) => void`<br/> | N
 
 ### RadioGroup Events
 
 name | params | description
 -- | -- | --
-change | `(value: T, context: { e: Event })` | \-
+change | `(value: T, context: { e: Event; name?:string })` | \-
 
 ### CSS Variables
 

--- a/src/radio/radio.md
+++ b/src/radio/radio.md
@@ -21,7 +21,8 @@ maxContentRow | Number | 5 | 内容最大行数限制 | N
 maxLabelRow | Number | 3 | 主文案最大行数限制 | N
 name | String | - | HTML 元素原生属性 | N
 placement | String | left | 复选框和内容相对位置。可选项：left/right | N
-value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`string \| number \| boolean` | N
+readonly | Boolean | false | 只读状态 | N
+value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`T` | N
 onChange | Function |  | TS 类型：`(checked: boolean, context: { e: Event }) => void`<br/>选中状态变化时触发 | N
 
 ### Radio Events
@@ -45,13 +46,13 @@ options | Array | - | 单选组件按钮形式。RadioOption 数据类型为 str
 placement | String | left | 复选框和内容相对位置。可选项：left/right | N
 value | String / Number / Boolean | - | 选中的值。支持语法糖 `v-model` 或 `v-model:value`。TS 类型：`T` `type RadioValue = string \| number \| boolean`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/radio/type.ts) | N
 defaultValue | String / Number / Boolean | - | 选中的值。非受控属性。TS 类型：`T` `type RadioValue = string \| number \| boolean`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/radio/type.ts) | N
-onChange | Function |  | TS 类型：`(value: T, context: { e: Event }) => void`<br/>选中值发生变化时触发 | N
+onChange | Function |  | TS 类型：`(value: T, context: { e: Event; name?:string }) => void`<br/>选中值发生变化时触发, `context.name` 指 RadioGroup 的 name 属性 | N
 
 ### RadioGroup Events
 
 名称 | 参数 | 描述
 -- | -- | --
-change | `(value: T, context: { e: Event })` | 选中值发生变化时触发
+change | `(value: T, context: { e: Event; name?:string })` | 选中值发生变化时触发, `context.name` 指 RadioGroup 的 name 属性
 
 ### CSS Variables
 

--- a/src/radio/radio.md
+++ b/src/radio/radio.md
@@ -21,7 +21,7 @@ maxContentRow | Number | 5 | 内容最大行数限制 | N
 maxLabelRow | Number | 3 | 主文案最大行数限制 | N
 name | String | - | HTML 元素原生属性 | N
 placement | String | left | 复选框和内容相对位置。可选项：left/right | N
-readonly | Boolean | false | 只读状态 | N
+readonly | Boolean | undefined | 只读状态 | N
 value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`T` | N
 onChange | Function |  | TS 类型：`(checked: boolean, context: { e: Event }) => void`<br/>选中状态变化时触发 | N
 

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -1,4 +1,4 @@
-import { inject, computed, defineComponent, Ref, readonly } from 'vue';
+import { inject, computed, defineComponent, Ref } from 'vue';
 import { CheckIcon, CheckCircleFilledIcon } from 'tdesign-icons-vue-next';
 import { useDefault } from '../shared';
 import config from '../config';

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -1,4 +1,4 @@
-import { inject, computed, defineComponent, Ref } from 'vue';
+import { inject, computed, defineComponent, Ref, readonly } from 'vue';
 import { CheckIcon, CheckCircleFilledIcon } from 'tdesign-icons-vue-next';
 import { useDefault } from '../shared';
 import config from '../config';
@@ -47,6 +47,7 @@ export default defineComponent({
       name: rootGroupProps.name || props.name,
       checked: radioChecked.value,
       disabled: isDisabled.value,
+      readonly: props.readonly,
       value: props.value,
     }));
 
@@ -91,12 +92,12 @@ export default defineComponent({
     };
 
     const radioOrgChange = (e: Event) => {
-      if (isDisabled.value) {
+      if (isDisabled.value || props.readonly) {
         return;
       }
       if (rootGroupChange) {
         const value = finalAllowUncheck.value && radioChecked.value ? undefined : props.value;
-        rootGroupChange(value, e);
+        rootGroupChange(value, { e, name: props.name });
       } else {
         const value = finalAllowUncheck.value ? !radioChecked.value : true;
         setInnerChecked(value, { e });

--- a/src/radio/type.ts
+++ b/src/radio/type.ts
@@ -83,7 +83,6 @@ export interface TdRadioProps<T = RadioValue> {
   placement?: 'left' | 'right';
   /**
    * 只读状态
-   * @default false
    */
   readonly?: boolean;
   /**

--- a/src/radio/type.ts
+++ b/src/radio/type.ts
@@ -6,7 +6,7 @@
 
 import { TNode, KeysType } from '../common';
 
-export interface TdRadioProps {
+export interface TdRadioProps<T = RadioValue> {
   /**
    * 是否允许取消选中
    * @default false
@@ -82,9 +82,14 @@ export interface TdRadioProps {
    */
   placement?: 'left' | 'right';
   /**
+   * 只读状态
+   * @default false
+   */
+  readonly?: boolean;
+  /**
    * 单选按钮的值
    */
-  value?: string | number | boolean;
+  value?: T;
   /**
    * 选中状态变化时触发
    */
@@ -142,9 +147,9 @@ export interface TdRadioGroupProps<T = RadioValue> {
    */
   modelValue?: T;
   /**
-   * 选中值发生变化时触发
+   * 选中值发生变化时触发, `context.name` 指 RadioGroup 的 name 属性
    */
-  onChange?: (value: T, context: { e: Event }) => void;
+  onChange?: (value: T, context: { e: Event; name?: string }) => void;
 }
 
 export type RadioOption = string | number | RadioOptionObj;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/TDesignOteam/tdesign-api/pull/428
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Radio): 新增 `readonly`属性 ，配置只读 
- feat(RadioGroup): `change`事件回调添加`name`属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
