### PR TITLE
feat: fix calendar confirmBtn when value is null

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -61,21 +61,17 @@ export default defineComponent({
 
     return () => {
       const title = renderTNodeJSX('title');
-      const confirmBtn = renderTNodeJSX('confirmBtn');
-      let newConfirmBtn = confirmBtn;
-      if (typeof confirmBtn === 'undefined') {
-        newConfirmBtn = null;
-      }
+      const confirmBtn = renderTNodeJSX('confirmBtn') === undefined ? null : renderTNodeJSX('confirmBtn');
       return (
         <div>
           {!props.usePopup ? (
-            <calendarTemplate ref={calendarTemplateRef} title={title} confirmBtn={newConfirmBtn}></calendarTemplate>
+            <calendarTemplate ref={calendarTemplateRef} title={title} confirmBtn={confirmBtn}></calendarTemplate>
           ) : (
             <t-popup visible={props.visible} placement="bottom" onVisibleChange={onPopupVisibleChange}>
               <calendarTemplate
                 ref={calendarTemplateRef}
                 title={title}
-                confirmBtn={newConfirmBtn}
+                confirmBtn={confirmBtn}
                 onVisibleChange={onVisibleChange}
               ></calendarTemplate>
             </t-popup>

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -62,16 +62,20 @@ export default defineComponent({
     return () => {
       const title = renderTNodeJSX('title');
       const confirmBtn = renderTNodeJSX('confirmBtn');
+      let newConfirmBtn = confirmBtn;
+      if (typeof confirmBtn === 'undefined') {
+        newConfirmBtn = null;
+      }
       return (
         <div>
           {!props.usePopup ? (
-            <calendarTemplate ref={calendarTemplateRef} title={title} confirmBtn={confirmBtn}></calendarTemplate>
+            <calendarTemplate ref={calendarTemplateRef} title={title} confirmBtn={newConfirmBtn}></calendarTemplate>
           ) : (
             <t-popup visible={props.visible} placement="bottom" onVisibleChange={onPopupVisibleChange}>
               <calendarTemplate
                 ref={calendarTemplateRef}
                 title={title}
-                confirmBtn={confirmBtn}
+                confirmBtn={newConfirmBtn}
                 onVisibleChange={onVisibleChange}
               ></calendarTemplate>
             </t-popup>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ✔️] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1612
<!--

-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
暂无

- fix(Calendar): 修复 `confirmBtn` 值为 `null` 时仍显示确认按钮的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
