### PR TITLE
fix(uselockscroll.ts): 修复多组件同时使用preventScrollThrough时,导致无法退出禁止滑动模式的问题

### DIFF
--- a/src/hooks/useLockScroll.ts
+++ b/src/hooks/useLockScroll.ts
@@ -3,7 +3,7 @@ import { useTouch } from '../_util/useTouch';
 import getScrollParent from '../_util/getScrollParent';
 import { supportsPassive } from '../_util/supportsPassive';
 
-let totalLockCount = 0;
+const totalLockCount = new Map<String, number>();
 let mounted: boolean = null;
 
 // 移植自vant：https://github.com/youzan/vant/blob/HEAD/src/composables/use-lock-scroll.ts
@@ -37,21 +37,22 @@ export function useLockScroll(rootRef: Ref<HTMLElement | undefined>, shouldLock:
     document.addEventListener('touchstart', touch.start);
     document.addEventListener('touchmove', onTouchMove, supportsPassive.value ? { passive: false } : false);
 
-    if (!totalLockCount) {
+    if (!totalLockCount.get(BODY_LOCK_CLASS)) {
       document.body.classList.add(BODY_LOCK_CLASS);
     }
 
-    totalLockCount += 1;
+    totalLockCount.set(BODY_LOCK_CLASS, (totalLockCount.get(BODY_LOCK_CLASS) ?? 0) + 1);
   };
 
   const unlock = () => {
-    if (totalLockCount) {
+    const sum = totalLockCount.values().reduce((acc, val) => acc + val, 0);
+    if (sum) {
       document.removeEventListener('touchstart', touch.start);
       document.removeEventListener('touchmove', onTouchMove);
 
-      totalLockCount -= 1;
+      totalLockCount.set(BODY_LOCK_CLASS, Math.max(totalLockCount.get(BODY_LOCK_CLASS) - 1, 0));
 
-      if (!totalLockCount) {
+      if (!totalLockCount.get(BODY_LOCK_CLASS)) {
         document.body.classList.remove(BODY_LOCK_CLASS);
       }
     }

--- a/src/hooks/useLockScroll.ts
+++ b/src/hooks/useLockScroll.ts
@@ -45,12 +45,12 @@ export function useLockScroll(rootRef: Ref<HTMLElement | undefined>, shouldLock:
   };
 
   const unlock = () => {
-    const sum = totalLockCount.values().reduce((acc, val) => acc + val, 0);
+    const sum = Array.from(totalLockCount.values()).reduce((acc, val) => acc + val, 0);
     if (sum) {
       document.removeEventListener('touchstart', touch.start);
       document.removeEventListener('touchmove', onTouchMove);
 
-      totalLockCount.set(BODY_LOCK_CLASS, Math.max(totalLockCount.get(BODY_LOCK_CLASS) - 1, 0));
+      totalLockCount.set(BODY_LOCK_CLASS, Math.max((totalLockCount.get(BODY_LOCK_CLASS) ?? 0) - 1, 0));
 
       if (!totalLockCount.get(BODY_LOCK_CLASS)) {
         document.body.classList.remove(BODY_LOCK_CLASS);


### PR DESCRIPTION
fix #1614

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：多组件同时使用preventScrollThrough，会导致页面无法滚动
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(useLockScroll): 修复多组件同时使用 `preventScrollThrough` 导致页面无法滚动的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
