### PR TITLE
fix(dialog): destroy未清除滚动锁定class

### DIFF
--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -61,7 +61,7 @@ function create(options: Partial<TdDialogProps> | string): DialogInstance {
     onClosed: () => {
       callFn('onClosed');
       // 卸载创建的app
-      // 修复调用destory未清除滚动锁定问题
+      // 修复调用destroy未清除滚动锁定问题
       nextTick(() => {
         params.destroyOnClose && app.unmount();
       });

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -61,7 +61,10 @@ function create(options: Partial<TdDialogProps> | string): DialogInstance {
     onClosed: () => {
       callFn('onClosed');
       // 卸载创建的app
-      params.destroyOnClose && app.unmount();
+      // 修复调用destory未清除滚动锁定问题
+      nextTick(() => {
+        params.destroyOnClose && app.unmount();
+      });
     },
   });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

调用Dialog instance destroy方法后未清除滚动锁定class
复现地址：
https://codesandbox.io/p/devbox/y35jmd?embed=1&file=%2Fsrc%2FApp.vue

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题：当使用Dialog instance的destroy后未清除body上的滚动锁定class

分析：
1、在调用destory时，会触发popup组件中的innerVisible的变更，从而触发Transition的onAfterLeave回调
2、在popup的onAfterLeave回调中会更改popup的wrapperVisible的值并调用props.onClosed方法
3、props.onClosed为Dialog中create函数初始化，create函数中触发了用户传入的onClosed回调和app卸载方法
4、app.unmount时会清除所有副作用并触发组件的onBeforeUnmount钩子函数，导致useLockScroll中watch(shouldLock)副作用函数未执行。而在onBeforeUnmount的钩子函数中，shouldLock（可变）拿到最新的值为fasle，从而未触发unlock方法。

修复思路：
修改影响范围最小化，在create函数的onClosed回调中，将app卸载放在nextTick中，让副作用函数执行后卸载。
![image](https://github.com/user-attachments/assets/01a67ad5-d821-45e5-aed6-f3cd2b3c37d1)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复函数式调用 `destroy()` 销毁弹框时未移除用于锁定背景滚动的 `class` 类名

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
