### PR TITLE
fix(DropdownMenu): solve the problem of onMenuClosed still being trig…

### DIFF
--- a/src/dropdown-menu/dropdown-menu.tsx
+++ b/src/dropdown-menu/dropdown-menu.tsx
@@ -60,7 +60,7 @@ export default defineComponent({
 
     // 通过 slots.default 子成员，计算标题栏选项
     const menuTitles = computed(() =>
-      menuItems.value.map((item: any, index: number) => {
+      menuItems.value?.map((item: any, index: number) => {
         const { keys, label, value, modelValue, defaultValue, disabled, options } = item.props as TdDropdownItemProps;
         const currentValue = value || modelValue || defaultValue;
         const target = options?.find((item: any) => lodashGet(item, keys?.value ?? 'value') === currentValue);
@@ -78,7 +78,7 @@ export default defineComponent({
         }
         return {
           labelProps: label,
-          label: label || target.label,
+          label: label || lodashGet(target, keys?.label ?? 'label'),
           disabled: disabled !== undefined && disabled !== false,
         };
       }),
@@ -144,6 +144,7 @@ export default defineComponent({
 
     // dropdown-menu外面点击触发dropdown下拉框收起
     onClickOutside(refBar, () => {
+      if (state.activeId === null) return;
       collapseMenu();
       props.onMenuClosed?.({ trigger: 'outside' });
     });


### PR DESCRIPTION
…gered in the collapsed state

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
https://stackblitz.com/edit/eahasszv-zzppy1on?file=src%2Fdemo.vue


<img width="1294" alt="企业微信截图_17394371655633" src="https://github.com/user-attachments/assets/10e9e03a-f0fd-4ec1-a5a9-9ee6138c9d63" />

<img width="1895" alt="企业微信截图_17394372354047" src="https://github.com/user-attachments/assets/6efdd05e-d95a-478a-81f1-f40924ca8052" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DropdownMenu): 解决收起状态下 `onMenuClosed` 仍被触发的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
