### PR TITLE
fix(tabbar): Update itemCount in render function to avoid console warning

### DIFF
--- a/src/tab-bar/tab-bar.tsx
+++ b/src/tab-bar/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, provide, Ref, computed, toRefs, onMounted } from 'vue';
+import { defineComponent, ref, provide, Ref, computed, toRefs, VNode } from 'vue';
 import TabBarProps from './props';
 import config from '../config';
 import { useDefault, useChildSlots } from '../shared';
@@ -18,14 +18,6 @@ export default defineComponent({
     const [activeValue] = useDefault(props, context.emit, 'value', 'change');
     const defaultIndex: Ref<number> = ref(-1);
     const itemCount = ref(0);
-
-    onMounted(() => {
-      const nodes = context.slots.default && context.slots.default();
-      if (nodes !== undefined) {
-        const childSlots = useChildSlots(`${prefix}-tab-bar-item`);
-        itemCount.value = childSlots.length;
-      }
-    });
 
     const updateChild = (currentValue: number | string) => {
       activeValue.value = currentValue;
@@ -49,10 +41,26 @@ export default defineComponent({
       updateChild,
     });
 
-    return () => (
-      <div class={rootClass.value} role="tablist">
-        {renderTNodeJSX('default')}
-      </div>
-    );
+    // 在渲染函数中调用插槽函数并更新子节点数量
+    const updateItemCount = (vNodes?: VNode[]) => {
+      if (!vNodes || !Array.isArray(vNodes)) {
+        itemCount.value = 0;
+        return;
+      }
+
+      const childSlots = useChildSlots(`${prefix}-tab-bar-item`, vNodes);
+      itemCount.value = childSlots.length;
+    };
+
+    return () => {
+      const vNodes = context.slots.default ? context.slots.default() : [];
+      updateItemCount(vNodes);
+
+      return (
+        <div class={rootClass.value} role="tablist">
+          {renderTNodeJSX('default')}
+        </div>
+      );
+    };
   },
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1188 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
方案：
移除 onMounted 钩子中直接调用插槽函数的代码，避免 Vue 警告。增加 updateItemCount 函数，确保每次渲染时都能获取最新的子节点数量。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabbar): 修复控制台告警，优化子节点数量更新逻辑

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
