### PR TITLE
feat(upload): supports custom errors display

### DIFF
--- a/src/config-provider/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/config-provider/__test__/__snapshots__/demo.test.jsx.snap
@@ -320,6 +320,7 @@ exports[`ConfigProvider > ConfigProvider mobileVue demo works fine 1`] = `
             type="file"
           />
           <!---->
+          <!---->
         </div>
       </div>
       
@@ -7350,6 +7351,7 @@ exports[`ConfigProvider > ConfigProvider uploadEnVue demo works fine 1`] = `
         multiple=""
         type="file"
       />
+      <!---->
       <!---->
     </div>
   </div>

--- a/src/form/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/form/__test__/__snapshots__/demo.test.jsx.snap
@@ -1586,6 +1586,7 @@ exports[`Form > Form horizontalVue demo works fine 1`] = `
               type="file"
             />
             <!---->
+            <!---->
           </div>
           
         </div>
@@ -3364,6 +3365,7 @@ exports[`Form > Form mobileVue demo works fine 1`] = `
                     type="file"
                   />
                   <!---->
+                  <!---->
                 </div>
                 
               </div>
@@ -4990,6 +4992,7 @@ exports[`Form > Form verticalVue demo works fine 1`] = `
               multiple=""
               type="file"
             />
+            <!---->
             <!---->
           </div>
           

--- a/src/upload/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/upload/__test__/__snapshots__/demo.test.jsx.snap
@@ -43,6 +43,7 @@ exports[`Upload > Upload baseVue demo works fine 1`] = `
       type="file"
     />
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -134,6 +135,7 @@ exports[`Upload > Upload customVue demo works fine 1`] = `
         type="file"
       />
       <!---->
+      <!---->
     </div>
   </div>
   <div
@@ -218,6 +220,7 @@ exports[`Upload > Upload customVue demo works fine 1`] = `
         type="file"
       />
       <!---->
+      <!---->
     </div>
   </div>
 </div>
@@ -299,6 +302,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
             hidden=""
             type="file"
           />
+          <!---->
           <!---->
         </div>
       </div>
@@ -546,6 +550,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
             type="file"
           />
           <!---->
+          <!---->
         </div>
       </div>
       
@@ -782,6 +787,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
             type="file"
           />
           <!---->
+          <!---->
         </div>
       </div>
       <div
@@ -913,6 +919,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
             type="file"
           />
           <!---->
+          <!---->
         </div>
       </div>
       
@@ -1026,6 +1033,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
               type="file"
             />
             <!---->
+            <!---->
           </div>
         </div>
         <div
@@ -1109,6 +1117,7 @@ exports[`Upload > Upload mobileVue demo works fine 1`] = `
               hidden=""
               type="file"
             />
+            <!---->
             <!---->
           </div>
         </div>
@@ -1344,6 +1353,7 @@ exports[`Upload > Upload multipleVue demo works fine 1`] = `
       type="file"
     />
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -1562,6 +1572,7 @@ exports[`Upload > Upload statusVue demo works fine 1`] = `
         type="file"
       />
       <!---->
+      <!---->
     </div>
   </div>
   <div
@@ -1692,6 +1703,7 @@ exports[`Upload > Upload statusVue demo works fine 1`] = `
         multiple=""
         type="file"
       />
+      <!---->
       <!---->
     </div>
   </div>

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -37,6 +37,7 @@ export default defineComponent({
     const {
       disabled,
       displayFiles,
+      uploadErrorsDisplay,
       uploading,
       inputRef,
       uploadFilePercent,
@@ -94,8 +95,27 @@ export default defineComponent({
               <CloseCircleIcon size="24" />
             )}
             {file.status === 'fail' && (
-              <div class={`${uploadClass.value}__progress-text`}>{globalConfig.value.progress.failText}</div>
+              <div class={`${uploadClass.value}__progress-text`}>
+                {file.response?.error && !uploadErrorsDisplay.value.length && file.response?.error.length <= 6
+                  ? file.response.error
+                  : globalConfig.value.progress.failText}
+              </div>
             )}
+          </div>
+        );
+      }
+    };
+
+    // 渲染组件底部自定义错误信息面板
+    const renderErrorsDisplay = () => {
+      if (uploadErrorsDisplay.value.length) {
+        return (
+          <div class={`${uploadClass.value}__error`}>
+            {uploadErrorsDisplay.value.map((error, index) => (
+              <div class={`${uploadClass.value}__error-text`} key={index}>
+                {error}
+              </div>
+            ))}
           </div>
         );
       }
@@ -161,6 +181,7 @@ export default defineComponent({
             index={initialIndex.value}
             onClose={handleImageClose}
           />
+          {renderErrorsDisplay()}
         </div>
       );
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #1823
fix #1707

### 相关 PRs
https://github.com/Tencent/tdesign-common/pull/2122

### 💡 需求背景和解决方案

桌面端的upload支持从response.error自定义错误显示，现在移动端文档援引桌面端有提及（现未实现）。请官方评估需求设计是否合理，目前考虑移动端的布局中，错误文本不超过6个全角字符时，上传item内可容纳。超过6个字符会统一（多文件场景）在整个上传组件底部显示错误信息。评论附图

### 📝 更新日志

- feat(Upload): 上传组件支持自定义错误文本

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
