### PR TITLE
fix(Cascader): 修复开启 `checkStrictly`，懒加载时选中值丢失的问题

### DIFF
--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -148,7 +148,7 @@ export default defineComponent({
       }
     };
 
-    const handleSelect = (value: RadioValue, level: number, emitPick = true) => {
+    const handleSelect = (value: RadioValue, level: number, fromHandler = true) => {
       const keys = props.keys as KeysType;
       const index = items[level].findIndex((item: any) => lodashGet(item, keys?.value ?? 'value') === value);
       const item = items[level][index];
@@ -156,7 +156,7 @@ export default defineComponent({
         return;
       }
 
-      if (emitPick) {
+      if (fromHandler) {
         props.onPick?.({
           value: lodashGet(item, keys?.value ?? 'value'),
           label: lodashGet(item, keys?.label ?? 'label'),
@@ -165,7 +165,7 @@ export default defineComponent({
         });
       }
 
-      if (props.checkStrictly && selectedValue.includes(String(value))) {
+      if (props.checkStrictly && selectedValue.includes(String(value)) && fromHandler) {
         cancelSelect(value, level, index, item);
       } else {
         chooseSelect(value, level, index, item);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1807
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复开启 `checkStrictly`，懒加载时选中值丢失的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
