### PR TITLE
feat(Calendar): support readonly prop

### DIFF
--- a/src/calendar/calendar.en-US.md
+++ b/src/calendar/calendar.en-US.md
@@ -11,6 +11,7 @@ firstDayOfWeek | Number | 0 | \- | N
 format | Function | - | Typescript：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/calendar/type.ts) | N
 maxDate | Number / Date | - | Typescript：` number \| Date` | N
 minDate | Number / Date | - | Typescript：` number \| Date` | N
+readonly | Boolean | - | `1.9.3` | N
 switchMode | String | none | options: none/month/year-month | N
 title | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 type | String | 'single' | options: single/multiple/range | N

--- a/src/calendar/calendar.md
+++ b/src/calendar/calendar.md
@@ -11,6 +11,7 @@ firstDayOfWeek | Number | 0 | 第一天从星期几开始，默认 0 = 周日 | 
 format | Function | - | 用于格式化日期的函数。TS 类型：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/calendar/type.ts) | N
 maxDate | Number / Date | - | 最大可选的日期，不传则默认半年后。TS 类型：` number \| Date` | N
 minDate | Number / Date | - | 最小可选的日期，不传则默认今天。TS 类型：` number \| Date` | N
+readonly | Boolean | - | `1.9.3`。是否只读，只读状态下不能选择日期 | N
 switchMode | String | none | 切换模式。 `none` 表示水平方向平铺展示所有月份； `month` 表示支持按月切换， `year-month` 表示既按年切换，也支持按月切换。可选项：none/month/year-month | N
 title | String / Slot / Function | - | 标题，不传默认为“请选择日期”。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-mobile-vue/blob/develop/src/common.ts) | N
 type | String | 'single' | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N

--- a/src/calendar/props.ts
+++ b/src/calendar/props.ts
@@ -30,6 +30,8 @@ export default {
   minDate: {
     type: [Number, Date] as PropType<TdCalendarProps['minDate']>,
   },
+  /** 是否只读，只读状态下不能选择日期 */
+  readonly: Boolean,
   /** 切换模式。 `none` 表示水平方向平铺展示所有月份； `month` 表示支持按月切换， `year-month` 表示既按年切换，也支持按月切换 */
   switchMode: {
     type: String as PropType<TdCalendarProps['switchMode']>,

--- a/src/calendar/template.tsx
+++ b/src/calendar/template.tsx
@@ -133,7 +133,7 @@ export default defineComponent({
 
     // 选择日期
     const handleSelect = (year: number, month: number, date: number, dateItem: TDate) => {
-      if (dateItem.type === 'disabled') return;
+      if (dateItem.type === 'disabled' || props.readonly) return;
       const selected = new Date(year, month, date);
 
       if (props.type === 'range' && Array.isArray(selectedDate.value)) {

--- a/src/calendar/type.ts
+++ b/src/calendar/type.ts
@@ -31,6 +31,10 @@ export interface TdCalendarProps {
    */
   minDate?: number | Date;
   /**
+   * 是否只读，只读状态下不能选择日期
+   */
+  readonly?: boolean;
+  /**
    * 切换模式。 `none` 表示水平方向平铺展示所有月份； `month` 表示支持按月切换， `year-month` 表示既按年切换，也支持按月切换
    * @default none
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 相关 PRs
https://github.com/TDesignOteam/tdesign-api/pull/654
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Calendar): 新增 `readonly` 属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
