### PR TITLE
feat: component upload add removeBtn prop and demo

### DIFF
--- a/src/upload/demos/multiple.vue
+++ b/src/upload/demos/multiple.vue
@@ -63,6 +63,7 @@ const files = ref([
     url: 'https://tdesign.gtimg.com/mobile/demos/upload4.png',
     name: 'uploaded1.png',
     type: 'image',
+    removeBtn: false,
   },
   {
     url: 'https://tdesign.gtimg.com/mobile/demos/upload6.png',

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -138,10 +138,12 @@ export default defineComponent({
                 />
               )}
               {renderStatus(file)}
-              <CloseIcon
-                class={`${uploadClass.value}__delete-btn`}
-                onClick={({ e }: any) => onInnerRemove({ e, file, index })}
-              />
+              {file.removeBtn !== false && (
+                <CloseIcon
+                  class={`${uploadClass.value}__delete-btn`}
+                  onClick={({ e }: any) => onInnerRemove({ e, file, index })}
+                />
+              )}
             </div>
           ))}
           {content()}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-mobile-vue/issues/1902
【Upload】 组件新增 removeBtn 属性，并支持在文件中设置单个图片的 removeBtn 属性 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
组件新增` removeBtn `属性，并支持在文件中设置单个图片的 `removeBtn` 属性 
在图片删除按钮的渲染逻辑处添加一个`removeBtn`的布尔判断来解决这个问题，使用时给`files`中的特定图片添加`removeBtn`属性为`false`，即可隐藏删除图标。
<img width="791" height="479" alt="image" src="https://github.com/user-attachments/assets/02133174-81b1-4188-ac7d-b7c489279fa5" />
<img width="345" height="154" alt="image" src="https://github.com/user-attachments/assets/bb8c6c5c-2214-4ccf-8b01-675cd14d51c9" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
有些特定图片的右上角没有删除按钮，无法对已存在的图片从upload组件中进行删除
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
