### PR TITLE
fix(slider): 修复设置min属性后刻度颜色错误

### DIFF
--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -366,9 +366,9 @@ export default defineComponent({
               `${sliderClass.value}__scale-item`,
               `${sliderClass.value}__scale-item--${props.theme}`,
               {
-                [`${sliderClass.value}__scale-item--active`]: !props.range && Number(innerValue.value) >= item.val,
                 [`${sliderClass.value}__scale-item--active`]:
-                  props.range && state.dotTopValue[1] >= item.val && item.val >= state.dotTopValue[0],
+                  (!props.range && Number(innerValue.value) >= item.val) ||
+                  (props.range && state.dotTopValue[1] >= item.val && item.val >= state.dotTopValue[0]),
                 [`${sliderClass.value}__scale-item--disabled`]: isDisabled.value,
                 [`${sliderClass.value}__scale-item--hidden`]:
                   ((index === 0 || index === state.scaleArray.length - 1) && props.theme === 'capsule') ||


### PR DESCRIPTION
fix(slider): 修复了 renderScale 方法中因重复的激活状态判断逻辑，导致单游标滑块刻度无法正确应用主题色的问题。

fix #1898

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[#1898](https://github.com/Tencent/tdesign-mobile-vue/issues/1898)


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
**需求背景：** Slider 组件在设置 `min` 属性后，滑块左侧的刻度颜色没有正确应用主题色。

**根本原因：** `renderScale` 方法中，用于计算刻度激活状态的 class 对象里存在重复的 `__scale-item--active` 键，导致单游标滑块的判断逻辑被覆盖，激活样式始终无法生效。

**解决方案：** 将两个互斥的判断条件用逻辑或 (`||`) 合并，确保单游标和双游标模式下都能正确计算刻度的激活状态。本次修改不涉及 API 变动。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(slider): 修复设置 `min` 属性后刻度无法正确应用主题色的问题。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
