### PR TITLE
feat(indexes): add current API

### DIFF
--- a/src/indexes/indexes.en-US.md
+++ b/src/indexes/indexes.en-US.md
@@ -6,6 +6,8 @@
 
 name | type | default | description | required
 -- | -- | -- | -- | --
+current | String / Number | - | `v-model` and `v-model:current` is supported | N
+defaultCurrent | String / Number | - | uncontrolled property | N
 indexList | Array | - | Typescript：`Array<string \| number>` | N
 sticky | Boolean | true | Typescript：`Boolean` | N
 stickyOffset | Number | 0 | \- | N

--- a/src/indexes/indexes.md
+++ b/src/indexes/indexes.md
@@ -6,6 +6,8 @@
 
 名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
+current | String / Number | - | 索引列表的激活项，默认首项。支持语法糖 `v-model` 或 `v-model:current` | N
+defaultCurrent | String / Number | - | 索引列表的激活项，默认首项。非受控属性 | N
 indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`Array<string \| number>` | N
 sticky | Boolean | true | 索引是否吸顶，默认为true。TS 类型：`Boolean` | N
 stickyOffset | Number | 0 | 锚点吸顶时与顶部的距离	 | N

--- a/src/indexes/props.ts
+++ b/src/indexes/props.ts
@@ -8,6 +8,19 @@ import { TdIndexesProps } from './type';
 import { PropType } from 'vue';
 
 export default {
+  /** 索引列表的激活项，默认首项 */
+  current: {
+    type: [String, Number] as PropType<TdIndexesProps['current']>,
+    default: undefined,
+  },
+  modelValue: {
+    type: [String, Number] as PropType<TdIndexesProps['current']>,
+    default: undefined,
+  },
+  /** 索引列表的激活项，默认首项，非受控属性 */
+  defaultCurrent: {
+    type: [String, Number] as PropType<TdIndexesProps['defaultCurrent']>,
+  },
   /** 索引字符列表。不传默认 `A-Z` */
   indexList: {
     type: Array as PropType<TdIndexesProps['indexList']>,

--- a/src/indexes/type.ts
+++ b/src/indexes/type.ts
@@ -6,6 +6,18 @@
 
 export interface TdIndexesProps {
   /**
+   * 索引列表的激活项，默认首项
+   */
+  current?: string | number;
+  /**
+   * 索引列表的激活项，默认首项，非受控属性
+   */
+  defaultCurrent?: string | number;
+  /**
+   * 索引列表的激活项，默认首项
+   */
+  modelValue?: string | number;
+  /**
    * 索引字符列表。不传默认 `A-Z`
    */
   indexList?: Array<string | number>;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- https://github.com/Tencent/tdesign-miniprogram/issues/2295
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
- feat(Indexes): 新增 `current` 属性，支持受控与非受控使用，用于自定义索引列表激活项
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
