### PR TITLE
fix(Picker): when the first item is a disabled item, the confirm event returns an incorrect value

### DIFF
--- a/src/picker/picker.class.ts
+++ b/src/picker/picker.class.ts
@@ -132,7 +132,7 @@ class Picker {
     this.height = this.holder.offsetHeight || DEFAULT_HOLDER_HEIGHT;
     this.indicatorOffset = this.itemGroupHeight / 2 - this.itemHeight / 2;
     let curIndex = findIndexOfEnabledOption(this.pickerColumns, this.options.defaultIndex || 0, this.options.keys);
-    if (curIndex !== this.options.defaultIndex || 0) this.onChange(curIndex);
+    if (curIndex !== (this.options.defaultIndex || 0)) this.onChange(curIndex);
     this.itemClassName = `${classPrefix.value}-picker-item__item`;
     this.itemSelectedClassName = `${classPrefix.value}-picker-item__item--active`;
     this.startY = 0;

--- a/src/picker/utils.ts
+++ b/src/picker/utils.ts
@@ -26,7 +26,8 @@ export function findIndexOfEnabledOption(options: PickerColumn, startIndex: numb
   }
 
   // 双向搜索
-  for (let i = 0; i <= Math.max(limitStartIndex, options.length - limitStartIndex); i++) {
+  const maxOffset = Math.max(limitStartIndex, options.length - 1 - limitStartIndex);
+  for (let i = 0; i <= maxOffset; i++) {
     // Forward Search
     const forwardIdx = limitStartIndex + i;
     if (forwardIdx < options.length && !lodashGet(options[forwardIdx], disabledKey)) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景： 初始值为 0 项，且首项为禁用项时，此时激活项为第 1 项，但confirm 事件返回值为仍为 0 项

可复现链接：https://stackblitz.com/edit/xu2ks14m?file=src%2Fdemo.vue

其他改动点：
- 优化 findIndexOfEnabledOption()，改为 双向搜索（同时向前和向后查找），减少不必要的数组操作（slice and reverse）

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Picker): 修复初始值为 `0` 且禁用时，`confirm` 事件返回值错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
