### PR TITLE
fix(CountDown): avoid incorrect accumulation of time (#2007)

### DIFF
--- a/src/shared/useCountDown/index.ts
+++ b/src/shared/useCountDown/index.ts
@@ -22,7 +22,8 @@ export function useCountDown(props: TdUseCountDownProps, visibility?: Ref<boolea
 
   visibility &&
     watch(visibility, (val) => {
-      if (val) {
+      if (val && autoStart) {
+        // 默认不开启倒计时才记录隐藏的时间
         count.value -= Date.now() - hiddenTime;
         rafFn();
       } else {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[[CountDown] 开启autoStart属性，离开当前标签页，倒计时未停止 #2007](https://github.com/Tencent/tdesign-mobile-vue/issues/2007)

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

问题描述：计算页面隐藏时间时没有考虑是否默认倒计时是开启状态，如果默认倒计时是关闭的，仍然会叠加离开屏幕时间

解决方案：计算离开屏幕时间时同时考虑默认倒计时的开启状态

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- fix(CountDown): 开启 `autostart` 后，置于后台的状态不更新时间

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
