### PR TITLE
feat(ImageViewer): add trigger source for close event

### DIFF
--- a/src/image-viewer/demos/base.vue
+++ b/src/image-viewer/demos/base.vue
@@ -1,14 +1,23 @@
 <template>
   <t-button block size="large" variant="outline" theme="primary" @click="visible = true">基础图片预览</t-button>
-  <t-image-viewer v-model:images="images" v-model:visible="visible" />
+  <t-image-viewer v-model:images="images" v-model:visible="visible" @index-change="onIndexChange" @close="onClose" />
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import type { ImageViewerCloseTrigger } from 'tdesign-mobile-vue';
 
 const visible = ref(false);
 const images = [
   'https://tdesign.gtimg.com/mobile/demos/swiper1.png',
   'https://tdesign.gtimg.com/mobile/demos/swiper2.png',
 ];
+
+const onIndexChange = (index: number, context: { trigger: 'prev' | 'next' }) => {
+  console.log('onIndexChange', index, context);
+};
+
+const onClose = (context: { trigger: ImageViewerCloseTrigger; visible: boolean; index: number }) => {
+  console.log('onClose', context);
+};
 </script>

--- a/src/image-viewer/image-viewer.en-US.md
+++ b/src/image-viewer/image-viewer.en-US.md
@@ -11,11 +11,11 @@ deleteBtn | Boolean / Slot / Function | false | Typescript：`boolean \| TNode`�
 images | Array | [] | Typescript：`Array<string \| ImageInfo>` `interface ImageInfo { url: string; align: 'start' \| 'center' \| 'end' }`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts) | N
 index | Number | - | `v-model:index` is supported | N
 defaultIndex | Number | - | uncontrolled property | N
-maxZoom | Number | 3 | Typescript：`Number` | N
+maxZoom | Number | 3 | \- | N
 showIndex | Boolean | false | \- | N
 visible | Boolean | false | hide or show image viewer。`v-model` and `v-model:visible` is supported | N
 defaultVisible | Boolean | false | hide or show image viewer。uncontrolled property | N
-onClose | Function |  | Typescript：`(context: { trigger: 'overlay' \| 'close-btn', visible: boolean, index: number }) => void`<br/> | N
+onClose | Function |  | Typescript：`(context: { trigger: ImageViewerCloseTrigger, visible: boolean, index: number }) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts)。<br/>`type ImageViewerCloseTrigger = 'image' \| 'overlay' \| 'close-btn'`<br/> | N
 onDelete | Function |  | Typescript：`(index: number) => void`<br/> | N
 onIndexChange | Function |  | Typescript：`(index: number, context: { trigger: 'prev' \| 'next' }) => void`<br/> | N
 
@@ -23,7 +23,7 @@ onIndexChange | Function |  | Typescript：`(index: number, context: { trigger: 
 
 name | params | description
 -- | -- | --
-close | `(context: { trigger: 'overlay' \| 'close-btn', visible: boolean, index: number })` | \-
+close | `(context: { trigger: ImageViewerCloseTrigger, visible: boolean, index: number })` | [see more ts definition](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts)。<br/>`type ImageViewerCloseTrigger = 'image' \| 'overlay' \| 'close-btn'`<br/>
 delete | `(index: number)` | \-
 index-change | `(index: number, context: { trigger: 'prev' \| 'next' })` | \-
 

--- a/src/image-viewer/image-viewer.md
+++ b/src/image-viewer/image-viewer.md
@@ -11,11 +11,11 @@ deleteBtn | Boolean / Slot / Function | false | 是否显示删除操作，前�
 images | Array | [] | 图片数组。TS 类型：`Array<string \| ImageInfo>` `interface ImageInfo { url: string; align: 'start' \| 'center' \| 'end' }`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts) | N
 index | Number | - | 当前预览图片所在的下标。支持语法糖 `v-model:index` | N
 defaultIndex | Number | - | 当前预览图片所在的下标。非受控属性 | N
-maxZoom | Number | 3 | 【开发中】最大放大比例。TS 类型：`Number` | N
+maxZoom | Number | 3 | 【开发中】最大放大比例 | N
 showIndex | Boolean | false | 是否显示页码 | N
 visible | Boolean | false | 隐藏/显示预览。支持语法糖 `v-model` 或 `v-model:visible` | N
 defaultVisible | Boolean | false | 隐藏/显示预览。非受控属性 | N
-onClose | Function |  | TS 类型：`(context: { trigger: 'overlay' \| 'close-btn', visible: boolean, index: number }) => void`<br/>关闭时触发 | N
+onClose | Function |  | TS 类型：`(context: { trigger: ImageViewerCloseTrigger, visible: boolean, index: number }) => void`<br/>关闭时触发。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts)。<br/>`type ImageViewerCloseTrigger = 'image' \| 'overlay' \| 'close-btn'`<br/> | N
 onDelete | Function |  | TS 类型：`(index: number) => void`<br/>点击删除操作按钮时触发 | N
 onIndexChange | Function |  | TS 类型：`(index: number, context: { trigger: 'prev' \| 'next' }) => void`<br/>预览图片切换时触发，`context.prev` 切换到上一张图片，`context.next` 切换到下一张图片 | N
 
@@ -23,7 +23,7 @@ onIndexChange | Function |  | TS 类型：`(index: number, context: { trigger: '
 
 名称 | 参数 | 描述
 -- | -- | --
-close | `(context: { trigger: 'overlay' \| 'close-btn', visible: boolean, index: number })` | 关闭时触发
+close | `(context: { trigger: ImageViewerCloseTrigger, visible: boolean, index: number })` | 关闭时触发。[详细类型定义](https://github.com/Tencent/tdesign-mobile-vue/tree/develop/src/image-viewer/type.ts)。<br/>`type ImageViewerCloseTrigger = 'image' \| 'overlay' \| 'close-btn'`<br/>
 delete | `(index: number)` | 点击删除操作按钮时触发
 index-change | `(index: number, context: { trigger: 'prev' \| 'next' })` | 预览图片切换时触发，`context.prev` 切换到上一张图片，`context.next` 切换到下一张图片
 

--- a/src/image-viewer/image-viewer.tsx
+++ b/src/image-viewer/image-viewer.tsx
@@ -12,7 +12,7 @@ import { usePrefixClass } from '../hooks/useClass';
 
 // inner components
 import { SwiperChangeSource, Swiper as TSwiper, SwiperItem as TSwiperItem } from '../swiper';
-import { TdImageViewerProps, ImageInfo } from './type';
+import { TdImageViewerProps, ImageInfo, ImageViewerCloseTrigger } from './type';
 
 const { prefix } = config;
 
@@ -112,10 +112,20 @@ export default defineComponent({
       state.extraDraggedX = 0;
     };
 
-    const handleClose = (e: Event, trigger: string) => {
+    const handleClose = (e: Event, trigger: ImageViewerCloseTrigger) => {
       beforeClose();
       setVisibleValue(false);
       emit('close', { trigger, e });
+    };
+
+    // 通过(事件委托)将点击事件绑定到组件根，判断点击目标
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'IMG') {
+        handleClose(e, 'image');
+      } else {
+        handleClose(e, 'overlay');
+      }
     };
 
     const handleDelete = () => {
@@ -393,8 +403,8 @@ export default defineComponent({
     return () => (
       <Transition name="fade">
         {visibleValue.value && (
-          <div ref={rootRef} class={`${imageViewerClass.value}`}>
-            <div class={`${imageViewerClass.value}__mask`} onClick={(e) => handleClose(e, 'overlay')} />
+          <div ref={rootRef} class={`${imageViewerClass.value}`} onClick={handleClick}>
+            <div class={`${imageViewerClass.value}__mask`} />
             <TSwiper
               ref={swiperRootRef}
               autoplay={false}

--- a/src/image-viewer/type.ts
+++ b/src/image-viewer/type.ts
@@ -34,7 +34,7 @@ export interface TdImageViewerProps {
    * 【开发中】最大放大比例
    * @default 3
    */
-  maxZoom?: Number;
+  maxZoom?: number;
   /**
    * 是否显示页码
    * @default false
@@ -58,7 +58,7 @@ export interface TdImageViewerProps {
   /**
    * 关闭时触发
    */
-  onClose?: (context: { trigger: 'overlay' | 'close-btn'; visible: boolean; index: number }) => void;
+  onClose?: (context: { trigger: ImageViewerCloseTrigger; visible: boolean; index: number }) => void;
   /**
    * 点击删除操作按钮时触发
    */
@@ -73,3 +73,5 @@ export interface ImageInfo {
   url: string;
   align: 'start' | 'center' | 'end';
 }
+
+export type ImageViewerCloseTrigger = 'image' | 'overlay' | 'close-btn';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-mobile-react/pull/811
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ImageViwer): 修复点击遮罩层 `close` 事件未触发，并补充触发源 `image`，表示点击图片关闭图片预览

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
