### PR TITLE
fix(calendar): 修复value存在时日历定位不准确问题

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -5,6 +5,7 @@ import props from './props';
 import { useTNodeJSX } from '../hooks/tnode';
 import TCalendarTemplate from './template';
 import { usePrefixClass } from '../hooks/useClass';
+import type { CalendarTrigger } from './type';
 
 const { prefix } = config;
 
@@ -34,20 +35,23 @@ export default defineComponent({
       context.emit('update:visible', v);
     };
 
-    const onPopupVisibleChange = (v: boolean) => {
-      if (!v) {
-        props.onClose?.('overlay');
-      } else {
-        nextTick(() => {
-          selectedValueIntoView();
-        });
-      }
+    const onPopupVisibleChange = (v: boolean, trigger: CalendarTrigger) => {
+      if (!v) props.onClose?.(trigger);
       context.emit('update:visible', v);
     };
 
     onMounted(() => {
       if (!props.usePopup) selectedValueIntoView();
     });
+
+    watch(
+      () => props.visible,
+      (val) => {
+        if (val) {
+          nextTick(() => selectedValueIntoView());
+        }
+      },
+    );
 
     watch(
       () => props.value,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- fix #2004 

### 💡 需求背景和解决方案
- 问题原因：每次打开弹窗时`visible = true`并不会执行`calendar`组件中`onPopupVisibleChange`回调，因为此回调在`popup`组件中`setCurrentVisible`仅在`currentVisible = false`才会执行回调函数

- 解决方案：在`calendar`组件中`watch`监听`visible`属性，只在当`visible = true`时执行`selectedValueIntoView`

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- fix(calendar): 修复`value`存在时日历定位不准确问题

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
