### PR TITLE
fix(empty): remove incorrect v-if directive in TSX

### DIFF
--- a/src/empty/empty.tsx
+++ b/src/empty/empty.tsx
@@ -23,7 +23,7 @@ export default defineComponent({
         const image = renderTNodeJSX('image');
         if (image) {
           if (typeof props.image === 'string') {
-            return <TImage v-if="typeof image === 'string'" src={props.image} />;
+            return <TImage src={props.image} />;
           }
           return image;
         }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复

### 💡 需求背景和解决方案


1. 使用Empty组件的时候，在浏览器控制台会提示 Failed to resolve directive: if ，看了源码发现是在tsx里混用了vue的v-if。
2. 解决方案：去除多余的v-if，使用方式没有任何变化。

### 📝 更新日志


- fix(Empty): 修复控制台 `Failed to resolve directive: if` 的告警

