### PR TITLE
chore: configure pnpm overrides

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -201,6 +201,11 @@
       "prettier --write"
     ]
   },
+  "pnpm": {
+    "overrides": {
+      "@vue/runtime-core": "3.3.8"
+    }
+  },
   "vetur": {
     "tags": "helper/tags.json",
     "attributes": "helper/attributes.json"


### PR DESCRIPTION
- pnpm 与 npm 依赖提升机制不同，出现 @vue/runtime-core 版本不一致，导致 pnpm instasll --> npm run build 构建失败