### PR TITLE
fix(dialog): support async onConfirm to prevent premature close

### DIFF
--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -1,5 +1,5 @@
 import { CloseIcon } from 'tdesign-icons-vue-next';
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 import { get, isString, isObject } from 'lodash-es';
 
 import TButton, { ButtonProps } from '../button';
@@ -55,7 +55,21 @@ export default defineComponent({
       context.emit('closed');
     };
 
-    const handleConfirm = (e: MouseEvent) => {
+    const confirmLoading = ref(false);
+
+    const handleConfirm = async (e: MouseEvent) => {
+      const onConfirm = props.onConfirm;
+      if (typeof onConfirm === 'function') {
+        const result = onConfirm({ e });
+        if (result instanceof Promise) {
+          confirmLoading.value = true;
+          try {
+            await result;
+          } finally {
+            confirmLoading.value = false;
+          }
+        }
+      }
       context.emit('update:visible', false);
       context.emit?.('confirm', { e });
     };
@@ -91,6 +105,7 @@ export default defineComponent({
     const confirmBtnProps = computed<ButtonProps>(() => ({
       theme: 'primary',
       ...calcBtn(props.confirmBtn),
+      loading: confirmLoading.value || (calcBtn(props.confirmBtn) as ButtonProps)?.loading,
     }));
 
     const cancelBtnProps = computed<ButtonProps>(() => ({

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -35,16 +35,15 @@ function create(options: Partial<TdDialogProps> | string): DialogInstance {
     ...(typeof options === 'string' ? { content: options } : options),
   };
 
-  function callFn<T>(fnType: DialogPropsFnName, context?: T): void {
+  function callFn<T>(fnType: DialogPropsFnName, context?: T): void | Promise<void> {
     const fn = props.value[fnType] || propsObject[fnType];
-    typeof fn === 'function' && fn(context as any);
+    return typeof fn === 'function' ? fn(context as any) : undefined;
   }
 
   const params = reactive({
     ...propsObject,
     onConfirm: (context: { e: MouseEvent }) => {
-      callFn('onConfirm', context);
-      params.visible = false;
+      return callFn('onConfirm', context);
     },
     onCancel: (context: { e: MouseEvent }) => {
       callFn('onCancel', context);

--- a/src/dialog/type.ts
+++ b/src/dialog/type.ts
@@ -97,9 +97,9 @@ export interface TdDialogProps {
    */
   onClosed?: () => void;
   /**
-   * 如果“确认”按钮存在，则点击“确认”按钮时触发
+   * 如果“确认”按钮存在，则点击“确认”按钮时触发。若返回 Promise，则 Promise 结束前确认按钮显示加载状态，Promise resolve 后关闭对话框
    */
-  onConfirm?: (context: { e: MouseEvent }) => void;
+  onConfirm?: (context: { e: MouseEvent }) => void | Promise<void>;
   /**
    * 如果蒙层存在，点击蒙层时触发
    */


### PR DESCRIPTION
## 关联 Issue
close #1988

## 问题描述
当 `onConfirm` 回调是异步函数时，Dialog 会在异步操作完成之前就立即关闭。

```js
Dialog.confirm({
  onConfirm: async () => {
    await remove(id); // Dialog 不等这个，直接关了
  }
})
```

## 根因分析

**调用链梳理：**
1. `dialog.tsx` 的 `handleConfirm` 直接 `emit("update:visible", false)`，完全不等 `onConfirm` 的返回值
2. `index.ts` 函数式调用时，`callFn` 调用了用户的 `onConfirm` 但**丢弃了返回值**，Promise 被忽略
3. `type.ts` 中 `onConfirm` 返回值类型是 `void`，TS 层面也不支持 Promise

## 改动说明

### `src/dialog/type.ts`
扩展 `onConfirm` 返回值类型，支持 `Promise<void>`（向下兼容，原有同步函数不受影响）

### `src/dialog/dialog.tsx`（核心）
- `handleConfirm` 改为 `async` 函数
- 若 `onConfirm` 返回 Promise，则 `await` 等待其 resolve 后再关闭
- 等待期间通过 `confirmLoading` ref 驱动按钮 loading 状态
- Promise reject 时 loading 结束，Dialog 保持打开（让用户可以重试）

### `src/dialog/index.ts`（函数式调用）
- `callFn` 改为透传返回值（`void | Promise<void>`）
- `onConfirm` 回调直接 `return callFn(...)` 将 Promise 传给 `dialog.tsx` 的 `handleConfirm` 统一处理
- 去掉 `onConfirm` 里的 `params.visible = false`，关闭时机统一由 `dialog.tsx` 在 await 后控制

## 兼容性
✅ 同步 `onConfirm` → 行为与改前完全一致（`result instanceof Promise` 为 false，跳过异步分支）
✅ 无 `onConfirm` → 立即关闭，行为不变
✅ 异步 `onConfirm` → 修复，等待 resolve 后关闭