### PR TITLE
fix(input): fix clearable not working in WeChat Work built-in browser

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -128,12 +128,33 @@ export default defineComponent({
 
     extendAPI({ focus, blur });
 
-    const handleClear = (e: TouchEvent) => {
+    const handleClear = (e: TouchEvent | MouseEvent) => {
       e.preventDefault();
       const val = props.type === 'number' ? undefined : '';
       setInnerValue(val);
       focus();
       props.onClear?.({ e });
+    };
+
+    // 记录是否正在进行 touch 操作，防止 touch 设备上 touchend 和 click 重复触发
+    let isTouchClearing = false;
+
+    const handleClearTouchStart = (e: TouchEvent) => {
+      // 阻止 touchstart 时 input 触发 blur，防止在企业微信等内置浏览器中
+      // clearable 按钮因 focused 变为 false 而从 DOM 消失，导致 touchend 无法触发
+      e.preventDefault();
+      isTouchClearing = true;
+    };
+
+    const handleClearTouchEnd = (e: TouchEvent) => {
+      isTouchClearing = false;
+      handleClear(e);
+    };
+
+    const handleClearClick = (e: MouseEvent) => {
+      // touch 设备上 touchend 已处理，忽略随后触发的 click 事件
+      if (isTouchClearing) return;
+      handleClear(e);
     };
 
     const handleFocus = (e: FocusEvent) => {
@@ -203,7 +224,7 @@ export default defineComponent({
       const renderClearable = () => {
         if (showClear.value) {
           return (
-            <div class={`${inputClass.value}__wrap--clearable-icon`} onTouchend={handleClear}>
+            <div class={`${inputClass.value}__wrap--clearable-icon`} onTouchstart={handleClearTouchStart} onTouchend={handleClearTouchEnd} onClick={handleClearClick}>
               <TCloseCircleFilledIcon />
             </div>
           );


### PR DESCRIPTION
## 关联 Issue
close #2047

## 问题描述
在企业微信内置浏览器中，带 `clearable` 属性的 `t-input` 点击清除按钮后无法清空输入内容。

## 根因分析

**事件触发链路（问题复现）：**

1. 用户点击清除按钮，触发 `touchstart`
2. `touchstart` 导致 input 触发 `blur` 事件，`focused.value` 变为 `false`
3. `showClear` 计算属性重新求值：`clearTrigger === "focus" && focused.value` → `false`，清除按钮**从 DOM 中移除**
4. `touchend` 事件找不到目标元素（已被移除），`handleClear` **无法触发**

这个问题在企业微信内置浏览器中特别明显，因为其 blur 事件在 touchstart 阶段就立即触发，而标准 Chrome 浏览器中 blur 触发时机较晚，不会影响 touchend。

## 修复方案

在清除按钮上增加 `onTouchstart` 事件处理，调用 `e.preventDefault()` 阻止浏览器默认行为，从而阻止 input 在 `touchstart` 阶段触发 `blur`，确保 `touchend` 能正常触发。

同时增加 `onClick` 事件兼容纯鼠标环境（PC 端），并通过 `isTouchClearing` 标记防止 touch 设备上 `touchend` 和模拟 `click` 重复触发清除逻辑。

**改动摘要（`src/input/input.tsx`）：**

```diff
- const handleClear = (e: TouchEvent) => {
+ const handleClear = (e: TouchEvent | MouseEvent) => {
    e.preventDefault();
    ...
  };

+ let isTouchClearing = false;
+
+ // touchstart 时 preventDefault，阻止 input blur，防止清除按钮从 DOM 消失
+ const handleClearTouchStart = (e: TouchEvent) => {
+   e.preventDefault();
+   isTouchClearing = true;
+ };
+
+ const handleClearTouchEnd = (e: TouchEvent) => {
+   isTouchClearing = false;
+   handleClear(e);
+ };
+
+ // 兼容 PC 端鼠标点击，touch 设备上忽略模拟 click
+ const handleClearClick = (e: MouseEvent) => {
+   if (isTouchClearing) return;
+   handleClear(e);
+ };

- <div ... onTouchend={handleClear}>
+ <div ... onTouchstart={handleClearTouchStart} onTouchend={handleClearTouchEnd} onClick={handleClearClick}>
```

## 兼容性
✅ 普通 Android/iOS 浏览器：`touchstart` → `touchend` 正常触发，`isTouchClearing` 标记防止 `click` 重复执行
✅ 企业微信内置浏览器：`touchstart` 的 `preventDefault` 阻止 input blur，清除按钮保留在 DOM 中，`touchend` 正常触发
✅ PC 端（鼠标操作）：无 touch 事件，`onClick` 正常触发 `handleClearClick`