### PR TITLE
fix(DateTimePicker): fixed invalid start and end props when showWeek is enabled

### DIFF
--- a/src/date-time-picker/date-time-picker.tsx
+++ b/src/date-time-picker/date-time-picker.tsx
@@ -110,19 +110,18 @@ export default defineComponent({
         second: globalConfig.value.secondLabel,
       };
 
-      const generateDayWithWeekColumn = (date: Dayjs) => {
+      const generateDayWithWeekColumn = (date: Dayjs, lower: number, upper: number) => {
         const startOfMonth = date.startOf('month');
-        const endOfMonth = date.endOf('month');
         const daysOfWeek = [];
         const type = 'date';
 
-        for (let i = 0; i <= endOfMonth.diff(startOfMonth, 'days'); i += 1) {
-          const currentDate = startOfMonth.add(i, 'days');
+        for (let i = lower; i <= upper; i += 1) {
+          const currentDate = startOfMonth.add(i - 1, 'days');
           const dayName = currentDate.format('ddd');
 
           daysOfWeek.push({
-            value: `${i + 1}`,
-            label: props.renderLabel ? props.renderLabel(type, i) : `${i + 1}${typeUnit[type] || ''} ${dayName}`,
+            value: `${i}`,
+            label: props.renderLabel ? props.renderLabel(type, i) : `${i}${typeUnit[type] || ''} ${dayName}`,
           });
         }
 
@@ -156,7 +155,7 @@ export default defineComponent({
         const lower = isInMinMonth ? minDay : 1;
         const upper = isInMaxMonth ? maxDay : dayjs(`${curYear}-${curMonth}`).daysInMonth();
         if (props.showWeek) {
-          generateDayWithWeekColumn(curDate.value);
+          generateDayWithWeekColumn(curDate.value, lower, upper);
         } else {
           generateColumn(lower, upper, 'date');
         }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2203
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DateTimePicker): 修复 `showWeek` 启用时 `start` 和 `end` 属性无效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
