### PR TITLE
fix(ImageViewer): fixed incorrect image position calculation in v-show scenarios

### DIFF
--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -1,4 +1,5 @@
 import { ref, shallowRef, Ref, ShallowRef, unref, watch, onMounted, onUnmounted } from 'vue';
+import { useResizeObserver } from './useResizeObserver';
 
 export type ElementOrRef = string | Element | null | undefined;
 
@@ -86,7 +87,7 @@ export default function useElementRect(
   rect: Ref<ElementRect>;
   updateElement: () => void;
 } {
-  const { immediate = true, resizeObserver = false } = options;
+  const { immediate = true, resizeObserver: enableResizeObserver = false } = options;
   const elementRef = shallowRef<HTMLElement | null>(null);
   const rect = ref<ElementRect>({
     top: 0,
@@ -96,7 +97,6 @@ export default function useElementRect(
     width: 0,
     height: 0,
   });
-  let resizeObserverInstance: ResizeObserver | null = null;
 
   const updateElement = () => {
     // 使用 unref 统一处理 Ref 和非 Ref 类型
@@ -109,31 +109,26 @@ export default function useElementRect(
     }
   };
 
-  const setupResizeObserver = () => {
-    if (!resizeObserver) return;
-
-    if (elementRef.value && window.ResizeObserver) {
-      resizeObserverInstance = new ResizeObserver(() => {
+  // 使用统一的 ResizeObserver hook
+  const { stop: stopResizeObserver, start: startResizeObserver } = useResizeObserver(
+    elementRef,
+    () => {
+      if (elementRef.value) {
         rect.value = getElementRect(elementRef.value);
-      });
-      resizeObserverInstance.observe(elementRef.value);
-    }
-  };
-
-  const cleanupResizeObserver = () => {
-    if (resizeObserverInstance) {
-      resizeObserverInstance.disconnect();
-      resizeObserverInstance = null;
-    }
-  };
+      }
+    },
+    { immediate: false, onResize: true, onVisibilityChange: false },
+  );
 
   // 监听 element 参数变化
   watch(
     () => unref(element),
     () => {
-      cleanupResizeObserver();
+      stopResizeObserver();
       updateElement();
-      setupResizeObserver();
+      if (enableResizeObserver) {
+        startResizeObserver();
+      }
     },
     { flush: 'post' },
   );
@@ -141,12 +136,14 @@ export default function useElementRect(
   onMounted(() => {
     if (immediate) {
       updateElement();
-      setupResizeObserver();
+      if (enableResizeObserver) {
+        startResizeObserver();
+      }
     }
   });
 
   onUnmounted(() => {
-    cleanupResizeObserver();
+    stopResizeObserver();
   });
 
   return {

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,0 +1,185 @@
+import { ref, Ref, onMounted, onUnmounted, watch, unref } from 'vue';
+
+export interface UseResizeObserverOptions {
+  /**
+   * 是否在尺寸从 0 变为非 0 时触发回调（用于处理 v-show 场景）
+   * @default false
+   */
+  onVisibilityChange?: boolean;
+  /**
+   * 是否在任何尺寸变化时都触发回调
+   * @default true
+   */
+  onResize?: boolean;
+  /**
+   * 是否立即开始观察
+   * @default true
+   */
+  immediate?: boolean;
+}
+
+export interface ResizeCallbackParams {
+  width: number;
+  height: number;
+  entry: ResizeObserverEntry;
+  /** 是否是从不可见变为可见（尺寸从 0 变为非 0） */
+  becameVisible: boolean;
+}
+
+export type ResizeCallback = (params: ResizeCallbackParams) => void;
+
+/**
+ * 通用的 ResizeObserver hook
+ * 支持监听元素尺寸变化，以及元素从不可见变为可见（v-show 场景）
+ *
+ * @param target 目标元素或 Ref
+ * @param callback 尺寸变化时的回调函数
+ * @param options 配置选项
+ *
+ * @example
+ * // 基础用法 - 监听尺寸变化
+ * useResizeObserver(elementRef, ({ width, height }) => {
+ *   console.log('尺寸变化:', width, height);
+ * });
+ *
+ * @example
+ * // 只监听可见性变化（v-show 场景）
+ * useResizeObserver(elementRef, ({ becameVisible }) => {
+ *   if (becameVisible) {
+ *     console.log('元素变为可见');
+ *   }
+ * }, { onVisibilityChange: true, onResize: false });
+ *
+ * @example
+ * // 同时监听尺寸变化和可见性变化
+ * useResizeObserver(elementRef, ({ width, height, becameVisible }) => {
+ *   if (becameVisible) {
+ *     // 元素从隐藏变为可见，重新初始化
+ *     initComponent();
+ *   }
+ * }, { onVisibilityChange: true });
+ */
+export function useResizeObserver(
+  target: Ref<HTMLElement | null | undefined> | HTMLElement | null | undefined,
+  callback: ResizeCallback,
+  options: UseResizeObserverOptions = {},
+) {
+  const { onVisibilityChange = false, onResize = true, immediate = true } = options;
+
+  const isSupported = typeof ResizeObserver !== 'undefined';
+  const previousSize = ref({ width: 0, height: 0 });
+  let observer: ResizeObserver | null = null;
+
+  const cleanup = () => {
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+  };
+
+  const observe = () => {
+    cleanup();
+
+    const element = unref(target);
+    if (!element || !isSupported) return;
+
+    // 初始化 previousSize
+    previousSize.value = {
+      width: element.offsetWidth || 0,
+      height: element.offsetHeight || 0,
+    };
+
+    observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        const { width: prevWidth, height: prevHeight } = previousSize.value;
+
+        // 检测是否从不可见变为可见（宽度或高度从 0 变为非 0）
+        const wasHidden = prevWidth === 0 || prevHeight === 0;
+        const isVisible = width > 0 && height > 0;
+        const becameVisible = wasHidden && isVisible;
+
+        // 检测尺寸是否发生变化
+        const sizeChanged = width !== prevWidth || height !== prevHeight;
+
+        // 更新记录的尺寸
+        previousSize.value = { width, height };
+
+        // 根据配置决定是否触发回调
+        const shouldTrigger = (onVisibilityChange && becameVisible) || (onResize && sizeChanged && !becameVisible);
+
+        if (shouldTrigger) {
+          callback({
+            width,
+            height,
+            entry,
+            becameVisible,
+          });
+        }
+      }
+    });
+
+    observer.observe(element);
+  };
+
+  // 监听 target 变化
+  if (typeof target === 'object' && target !== null && 'value' in target) {
+    watch(
+      () => unref(target),
+      (newEl, oldEl) => {
+        if (newEl !== oldEl) {
+          observe();
+        }
+      },
+      { flush: 'post' },
+    );
+  }
+
+  onMounted(() => {
+    if (immediate) {
+      observe();
+    }
+  });
+
+  onUnmounted(() => {
+    cleanup();
+  });
+
+  return {
+    /** 是否支持 ResizeObserver */
+    isSupported,
+    /** 手动停止观察 */
+    stop: cleanup,
+    /** 手动开始观察 */
+    start: observe,
+  };
+}
+
+/**
+ * 监听元素从不可见变为可见（专门用于 v-show 场景）
+ *
+ * @param target 目标元素或 Ref
+ * @param callback 元素变为可见时的回调
+ *
+ * @example
+ * useVisibilityObserver(elementRef, () => {
+ *   // 元素变为可见，重新计算布局
+ *   updateLayout();
+ * });
+ */
+export function useVisibilityObserver(
+  target: Ref<HTMLElement | null | undefined> | HTMLElement | null | undefined,
+  callback: () => void,
+) {
+  return useResizeObserver(
+    target,
+    ({ becameVisible }) => {
+      if (becameVisible) {
+        callback();
+      }
+    },
+    { onVisibilityChange: true, onResize: false },
+  );
+}
+
+export default useResizeObserver;

--- a/src/segmented/segmented.tsx
+++ b/src/segmented/segmented.tsx
@@ -1,9 +1,10 @@
-import { computed, defineComponent, h, nextTick, onMounted, onUnmounted, ref, toRefs, watch } from 'vue';
+import { computed, defineComponent, h, nextTick, onMounted, ref, toRefs, watch } from 'vue';
 import { isFunction } from 'lodash-es';
 import config from '../config';
 import props from './props';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
+import { useResizeObserver } from '../hooks/useResizeObserver';
 
 const { prefix } = config;
 
@@ -85,14 +86,11 @@ export default defineComponent({
       { deep: true },
     );
 
+    // 监听尺寸变化，适配 v-show 和动态布局场景
+    useResizeObserver(groupRef, () => updateThumb(), { onVisibilityChange: true });
+
     onMounted(() => {
       updateThumb();
-
-      if (typeof ResizeObserver !== 'undefined' && groupRef.value) {
-        const ro = new ResizeObserver(() => updateThumb());
-        ro.observe(groupRef.value);
-        onUnmounted(() => ro.disconnect());
-      }
     });
 
     return () => {

--- a/src/swiper/swiper.tsx
+++ b/src/swiper/swiper.tsx
@@ -1,4 +1,4 @@
-import { onMounted, computed, ref, provide, watch, onUnmounted, toRefs, defineComponent } from 'vue';
+import { onMounted, computed, ref, provide, watch, onUnmounted, toRefs, defineComponent, nextTick } from 'vue';
 import { isNumber } from 'lodash-es';
 import { useSwipe } from '../swipe-cell/useSwipe';
 import config from '../config';
@@ -8,6 +8,7 @@ import useVModel from '../hooks/useVModel';
 import { preventDefault } from '../shared/dom';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
+import { useVisibilityObserver } from '../hooks/useResizeObserver';
 
 const DEFAULT_SWIPER_NAVIGATION: SwiperNavigation = {
   paginationPosition: 'bottom',
@@ -318,10 +319,19 @@ export default defineComponent({
       moveDirection,
     });
 
-    onMounted(() => {
-      startAutoplay();
+    // 监听容器从不可见变为可见（v-show 场景），重新计算 item 位置
+    useVisibilityObserver(root, () => {
       updateItemPosition();
       updateContainerHeight();
+    });
+
+    onMounted(() => {
+      startAutoplay();
+      // 使用 nextTick 确保 DOM 完全渲染后再计算位置
+      nextTick(() => {
+        updateItemPosition();
+        updateContainerHeight();
+      });
     });
 
     onUnmounted(() => {


### PR DESCRIPTION


<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2212
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

- 新增 `useResizeObserver` hook，统一处理元素尺寸监听逻辑
- 重构 `useElementRect` 内部实现，使用统一的 ResizeObserver 管理

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 修复 `v-show` 场景下预览图片位置计算错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
