### PR TITLE
fix(Swiper): fix navigation not displaying when navigation prop is not passed

### DIFF
--- a/src/notice-bar/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/notice-bar/__test__/__snapshots__/demo.test.jsx.snap
@@ -1192,7 +1192,7 @@ exports[`NoticeBar > NoticeBar mobileVue demo works fine 1`] = `
         >
           <div>
             <div
-              class="t-swiper t-notice-bar__content--vertical"
+              class="t-swiper t-swiper--inside t-notice-bar__content--vertical"
             >
               <div
                 class="t-swiper__container"
@@ -1263,7 +1263,18 @@ exports[`NoticeBar > NoticeBar mobileVue demo works fine 1`] = `
                 
                 
               </div>
+              
               <!---->
+              <span
+                class="t-swiper-nav--vertical t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+              >
+                
+                
+                
+                
+                <!---->
+              </span>
+              
             </div>
           </div>
         </div>
@@ -1382,7 +1393,7 @@ exports[`NoticeBar > NoticeBar scrollingVue demo works fine 1`] = `
     >
       <div>
         <div
-          class="t-swiper t-notice-bar__content--vertical"
+          class="t-swiper t-swiper--inside t-notice-bar__content--vertical"
         >
           <div
             class="t-swiper__container"
@@ -1453,7 +1464,18 @@ exports[`NoticeBar > NoticeBar scrollingVue demo works fine 1`] = `
             
             
           </div>
+          
           <!---->
+          <span
+            class="t-swiper-nav--vertical t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+          >
+            
+            
+            
+            
+            <!---->
+          </span>
+          
         </div>
       </div>
     </div>

--- a/src/swiper/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/swiper/__test__/__snapshots__/demo.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`Swiper > Swiper baseVue demo works fine 1`] = `
   style="padding: 0px 16px;"
 >
   <div
-    class="t-swiper"
+    class="t-swiper t-swiper--inside"
   >
     <div
       class="t-swiper__container"
@@ -71,7 +71,18 @@ exports[`Swiper > Swiper baseVue demo works fine 1`] = `
       
       
     </div>
+    
     <!---->
+    <span
+      class="t-swiper-nav--horizontal t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+    >
+      
+      
+      
+      
+      <!---->
+    </span>
+    
   </div>
 </div>
 `;
@@ -261,7 +272,7 @@ exports[`Swiper > Swiper currentVue demo works fine 1`] = `
   style="padding: 0px 16px;"
 >
   <div
-    class="t-swiper"
+    class="t-swiper t-swiper--inside"
   >
     <div
       class="t-swiper__container"
@@ -327,7 +338,18 @@ exports[`Swiper > Swiper currentVue demo works fine 1`] = `
       
       
     </div>
+    
     <!---->
+    <span
+      class="t-swiper-nav--horizontal t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+    >
+      
+      
+      
+      
+      <!---->
+    </span>
+    
   </div>
   <div
     class="tdesign-demo-block-row"
@@ -564,7 +586,7 @@ exports[`Swiper > Swiper mobileVue demo works fine 1`] = `
         style="padding: 0px 16px;"
       >
         <div
-          class="t-swiper"
+          class="t-swiper t-swiper--inside"
         >
           <div
             class="t-swiper__container"
@@ -630,7 +652,18 @@ exports[`Swiper > Swiper mobileVue demo works fine 1`] = `
             
             
           </div>
+          
           <!---->
+          <span
+            class="t-swiper-nav--horizontal t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+          >
+            
+            
+            
+            
+            <!---->
+          </span>
+          
         </div>
       </div>
       
@@ -977,7 +1010,7 @@ exports[`Swiper > Swiper mobileVue demo works fine 1`] = `
         style="padding: 0px 16px;"
       >
         <div
-          class="t-swiper"
+          class="t-swiper t-swiper--inside"
         >
           <div
             class="t-swiper__container"
@@ -1043,7 +1076,18 @@ exports[`Swiper > Swiper mobileVue demo works fine 1`] = `
             
             
           </div>
+          
           <!---->
+          <span
+            class="t-swiper-nav--horizontal t-swiper-nav__dots t-swiper-nav--bottom t-swiper-nav--inside"
+          >
+            
+            
+            
+            
+            <!---->
+          </span>
+          
         </div>
         <div
           class="tdesign-demo-block-row"

--- a/src/swiper/swiper.tsx
+++ b/src/swiper/swiper.tsx
@@ -68,7 +68,7 @@ export default defineComponent({
     const moveDirection = ref(0);
 
     const navigationConfig = computed<SwiperNavigation>(() => {
-      if (props.navigation === true) {
+      if (props.navigation === true || props.navigation === undefined) {
         return DEFAULT_SWIPER_NAVIGATION;
       }
       if (typeof props.navigation === 'object' && props.navigation !== null) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复方案：将 undefined 情况与 true 一起处理，使其默认返回 DEFAULT_SWIPER_NAVIGATION 配置，
确保默认情况下显示 dots 类型的导航器。

navigationConfig  现在的行为是：
- navigation 未传入（undefined）或 true → 显示默认导航器（dots 类型）
- navigation 为 false → 禁用导航器
- navigation 为对象 → 合并默认配置使用
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Swiper): 修复不传入 `navigation` 属性时导航器不显示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
