### PR TITLE
fix(dialog): support custom onClick in actions

### DIFF
--- a/src/dialog/__test__/index.test.jsx
+++ b/src/dialog/__test__/index.test.jsx
@@ -239,6 +239,89 @@ describe('dialog', () => {
       expect(onClose).toHaveBeenCalledWith({ e: expect.any(MouseEvent), trigger: 'cancel' });
     });
 
+    it('should close dialog when action has no onClick', async () => {
+      const onCancel = vi.fn();
+      const onClose = vi.fn();
+      const wrapper = mount(Dialog, {
+        props: {
+          visible: true,
+          actions: [{ content: 'action' }],
+          onCancel,
+          onClose,
+        },
+      });
+
+      const $button = wrapper.findComponent(Button);
+      await $button.trigger('click');
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledWith({ e: expect.any(MouseEvent), trigger: 'cancel' });
+    });
+
+    it('should trigger each action onClick independently', async () => {
+      const onClickA = vi.fn();
+      const onClickB = vi.fn();
+      const wrapper = mount(Dialog, {
+        props: {
+          visible: true,
+          actions: [
+            { content: 'A', onClick: onClickA },
+            { content: 'B', onClick: onClickB },
+          ],
+        },
+      });
+
+      const $buttons = wrapper.findAllComponents(Button);
+      expect($buttons).toHaveLength(2);
+
+      await $buttons.at(1).trigger('click');
+      expect(onClickB).toHaveBeenCalledTimes(1);
+      expect(onClickA).not.toHaveBeenCalled();
+
+      await $buttons.at(0).trigger('click');
+      expect(onClickA).toHaveBeenCalledTimes(1);
+      expect(onClickB).toHaveBeenCalledTimes(1);
+    });
+
+    it('should passthrough action props (e.g. class) to button', async () => {
+      const wrapper = mount(Dialog, {
+        props: {
+          visible: true,
+          actions: [{ content: 'action', theme: 'danger', class: 'custom-action' }],
+        },
+      });
+
+      const $button = wrapper.findComponent(Button);
+      expect($button.props('theme')).toBe('danger');
+      expect($button.classes()).toContain('custom-action');
+    });
+
+    it('should run action onClick before beforeClose intercepts closing', async () => {
+      const onClick = vi.fn();
+      const onCancel = vi.fn();
+      // beforeClose reject 阻止关闭
+      const beforeClose = vi.fn(() => Promise.reject());
+      const wrapper = mount(Dialog, {
+        props: {
+          visible: true,
+          actions: [{ content: 'action', onClick }],
+          beforeClose,
+          onCancel,
+        },
+      });
+
+      const $button = wrapper.findComponent(Button);
+      await $button.trigger('click');
+      await nextTick();
+
+      // 用户 onClick 无条件先执行
+      expect(onClick).toHaveBeenCalledTimes(1);
+      // beforeClose 被触发用于拦截 cancel
+      expect(beforeClose).toHaveBeenCalledWith('cancel', { e: expect.any(MouseEvent) });
+      // 被拦截后不 emit cancel
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
     it(':cancel && confirm && close', async () => {
       const visible = true;
       const cancelBtn = 'cancel';

--- a/src/dialog/__test__/index.test.jsx
+++ b/src/dialog/__test__/index.test.jsx
@@ -215,6 +215,30 @@ describe('dialog', () => {
     });
   });
   describe('event', () => {
+    it('should support custom onClick in actions', async () => {
+      const onClick = vi.fn();
+      const onCancel = vi.fn();
+      const onClose = vi.fn();
+      const wrapper = mount(Dialog, {
+        props: {
+          visible: true,
+          actions: [{ content: 'action', onClick }],
+          onCancel,
+          onClose,
+        },
+      });
+
+      const $button = wrapper.findComponent(Button);
+      expect($button.props('onClick')).toBeTypeOf('function');
+
+      await $button.trigger('click');
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledWith(expect.any(MouseEvent));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledWith({ e: expect.any(MouseEvent), trigger: 'cancel' });
+    });
+
     it(':cancel && confirm && close', async () => {
       const visible = true;
       const cancelBtn = 'cancel';

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -133,13 +133,13 @@ export default defineComponent({
       context.emit('overlay-click', { e });
     };
 
-    const calcBtn = (btn: TdDialogProps['cancelBtn'] | TdDialogProps['confirmBtn']) => {
+    const calcBtn = (btn: TdDialogProps['cancelBtn'] | TdDialogProps['confirmBtn'] | ButtonProps): ButtonProps => {
       if (isString(btn)) {
         return { content: btn };
       }
 
       if (isObject(btn)) {
-        return btn;
+        return btn as ButtonProps;
       }
 
       return {};
@@ -148,7 +148,7 @@ export default defineComponent({
     const confirmBtnProps = computed<ButtonProps>(() => ({
       theme: 'primary',
       ...calcBtn(props.confirmBtn),
-      loading: confirmLoading.value || (calcBtn(props.confirmBtn) as ButtonProps)?.loading,
+      loading: confirmLoading.value || calcBtn(props.confirmBtn)?.loading,
     }));
 
     const cancelBtnProps = computed<ButtonProps>(() => ({
@@ -157,7 +157,7 @@ export default defineComponent({
     }));
 
     const actionsBtnProps = computed<ButtonProps[] | undefined>(() =>
-      Array.isArray(props.actions) ? props.actions.map((item) => calcBtn(item) as ButtonProps) : undefined,
+      Array.isArray(props.actions) ? props.actions.map((item) => calcBtn(item)) : undefined,
     );
 
     const renderButtonNode = (
@@ -202,11 +202,13 @@ export default defineComponent({
           return actionsBtnProps.value.map((item, index) => {
             const { onClick, ...buttonProps } = item;
             const handleActionClick = (e: MouseEvent) => {
-              onClick?.(e);
-              handleCancel(e);
+              onClick?.(e); // 不受 beforeClose 影响，无条件先执行
+              handleCancel(e); // 内部可能被 beforeClose reject 而不关闭
             };
 
-            return <TButton key={index} {...buttonProps} class={buttonClass.value} onClick={handleActionClick} />;
+            const key = `${isString(item.content) ? item.content : 'action'}-${index}`;
+
+            return <TButton key={key} {...buttonProps} class={buttonClass.value} onClick={handleActionClick} />;
           });
         }
 

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -156,7 +156,9 @@ export default defineComponent({
       ...calcBtn(props.cancelBtn),
     }));
 
-    const actionsBtnProps = computed(() => props.actions?.map((item) => calcBtn(item)));
+    const actionsBtnProps = computed<ButtonProps[] | undefined>(() =>
+      Array.isArray(props.actions) ? props.actions.map((item) => calcBtn(item) as ButtonProps) : undefined,
+    );
 
     const renderButtonNode = (
       btnType: 'cancelBtn' | 'confirmBtn',
@@ -197,9 +199,15 @@ export default defineComponent({
       };
       const renderActionsNode = () => {
         if (actionsBtnProps.value) {
-          return actionsBtnProps.value.map((item, index) => (
-            <TButton key={index} {...item} class={buttonClass.value} onClick={handleCancel} />
-          ));
+          return actionsBtnProps.value.map((item, index) => {
+            const { onClick, ...buttonProps } = item;
+            const handleActionClick = (e: MouseEvent) => {
+              onClick?.(e);
+              handleCancel(e);
+            };
+
+            return <TButton key={index} {...buttonProps} class={buttonClass.value} onClick={handleActionClick} />;
+          });
         }
 
         return renderTNodeJSX('actions');


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Closes #2252

### 💡 需求背景和解决方案

Dialog 渲染 actions 时，用户配置的 onClick 与内部 handleCancel 被 Vue 合并为数组，导致 Button 收到的 onClick 类型异常。

本次修改显式提取 action 的 onClick，并通过单一函数依次执行用户回调和 Dialog 关闭逻辑，确保传入 Button 的 onClick 始终为函数。同时补充回归测试，覆盖用户回调、cancel 和 close 事件。

### 📝 更新日志

- fix(Dialog): 修复 `actions` 配置 `onClick` 时按钮点击事件报错，⚠️ 配置项的 `onClick` 事件会无条件先执行，不受 `beforeClose` 影响

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 测试

- Dialog 单元测试：15 项通过
- TypeScript、ESLint、Prettier 检查通过