### PR TITLE
fix(Navbar): fix blank space at the bottom of navigation bar

### DIFF
--- a/src/navbar/__test__/__snapshots__/demo.test.jsx.snap
+++ b/src/navbar/__test__/__snapshots__/demo.test.jsx.snap
@@ -6,13 +6,13 @@ exports[`Navbar > Navbar baseVue demo works fine 1`] = `
 >
   
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-fcc0cda1=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -53,13 +53,13 @@ exports[`Navbar > Navbar baseVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-fcc0cda1=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -124,13 +124,13 @@ exports[`Navbar > Navbar baseVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-fcc0cda1=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -199,13 +199,13 @@ exports[`Navbar > Navbar baseVue demo works fine 1`] = `
 
 exports[`Navbar > Navbar customColorVue demo works fine 1`] = `
 <div
-  class="t-navbar t-safe-area-top t-navbar--visible-animation custom-navbar"
+  class="t-navbar t-navbar--visible-animation custom-navbar"
   data-v-3ef3b10f=""
   style="z-index: 1;"
 >
   <!---->
   <div
-    class="t-navbar__content"
+    class="t-navbar__content t-safe-area-top"
   >
     <div
       class="t-navbar__left"
@@ -263,13 +263,13 @@ exports[`Navbar > Navbar customColorVue demo works fine 1`] = `
 
 exports[`Navbar > Navbar imgVue demo works fine 1`] = `
 <div
-  class="t-navbar t-safe-area-top t-navbar--visible-animation"
+  class="t-navbar t-navbar--visible-animation"
   data-v-ed0b13d1=""
   style="z-index: 1;"
 >
   <!---->
   <div
-    class="t-navbar__content"
+    class="t-navbar__content t-safe-area-top"
   >
     <div
       class="t-navbar__left"
@@ -358,13 +358,13 @@ exports[`Navbar > Navbar leftTitleVue demo works fine 1`] = `
 >
   
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-593dba5f=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -419,13 +419,13 @@ exports[`Navbar > Navbar leftTitleVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-593dba5f=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -532,13 +532,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
       
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-fcc0cda1=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -579,13 +579,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-fcc0cda1=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -650,13 +650,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-fcc0cda1=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -742,14 +742,14 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
     >
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-0270c729=""
         data-v-614a1e54=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -864,14 +864,14 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
     >
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-0270c729=""
         data-v-ed0b13d1=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -979,13 +979,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
       
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-593dba5f=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -1040,13 +1040,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-593dba5f=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -1132,13 +1132,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
       
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation"
+        class="t-navbar t-navbar--visible-animation"
         data-v-f6e31b98=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -1193,13 +1193,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation custom-navbar"
+        class="t-navbar t-navbar--visible-animation custom-navbar"
         data-v-f6e31b98=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -1283,14 +1283,14 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
     >
       
       <div
-        class="t-navbar t-safe-area-top t-navbar--visible-animation custom-navbar"
+        class="t-navbar t-navbar--visible-animation custom-navbar"
         data-v-0270c729=""
         data-v-3ef3b10f=""
         style="z-index: 1;"
       >
         <!---->
         <div
-          class="t-navbar__content"
+          class="t-navbar__content t-safe-area-top"
         >
           <div
             class="t-navbar__left"
@@ -1352,13 +1352,13 @@ exports[`Navbar > Navbar mobileVue demo works fine 1`] = `
 
 exports[`Navbar > Navbar searchVue demo works fine 1`] = `
 <div
-  class="t-navbar t-safe-area-top t-navbar--visible-animation"
+  class="t-navbar t-navbar--visible-animation"
   data-v-614a1e54=""
   style="z-index: 1;"
 >
   <!---->
   <div
-    class="t-navbar__content"
+    class="t-navbar__content t-safe-area-top"
   >
     <div
       class="t-navbar__left"
@@ -1459,13 +1459,13 @@ exports[`Navbar > Navbar sizeVue demo works fine 1`] = `
 >
   
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation"
+    class="t-navbar t-navbar--visible-animation"
     data-v-f6e31b98=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"
@@ -1520,13 +1520,13 @@ exports[`Navbar > Navbar sizeVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-navbar t-safe-area-top t-navbar--visible-animation custom-navbar"
+    class="t-navbar t-navbar--visible-animation custom-navbar"
     data-v-f6e31b98=""
     style="z-index: 1;"
   >
     <!---->
     <div
-      class="t-navbar__content"
+      class="t-navbar__content t-safe-area-top"
     >
       <div
         class="t-navbar__left"

--- a/src/navbar/__test__/__snapshots__/index.test.jsx.snap
+++ b/src/navbar/__test__/__snapshots__/index.test.jsx.snap
@@ -2,12 +2,12 @@
 
 exports[`navbar > events > left-click 1`] = `
 <div
-  class="t-navbar t-navbar--fixed t-safe-area-top t-navbar--visible-animation"
+  class="t-navbar t-navbar--fixed t-navbar--visible-animation"
   style="z-index: 1;"
 >
   <!---->
   <div
-    class="t-navbar__content"
+    class="t-navbar__content t-safe-area-top"
   >
     <div
       class="t-navbar__left"
@@ -92,12 +92,12 @@ exports[`navbar > events > left-click 1`] = `
 
 exports[`navbar > events > right-click 1`] = `
 <div
-  class="t-navbar t-navbar--fixed t-safe-area-top t-navbar--visible-animation"
+  class="t-navbar t-navbar--fixed t-navbar--visible-animation"
   style="z-index: 1;"
 >
   <!---->
   <div
-    class="t-navbar__content"
+    class="t-navbar__content t-safe-area-top"
   >
     <div
       class="t-navbar__left"

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -21,12 +21,14 @@ export default defineComponent({
       navbarClass.value,
       {
         [`${navbarClass.value}--fixed`]: props.fixed,
-        [`${classPrefix.value}-safe-area-top`]: props.safeAreaInsetTop,
       },
       props.visible
         ? `${navbarClass.value}--visible${animationSuffix.value}`
         : `${navbarClass.value}--hide${animationSuffix.value}`,
     ]);
+
+    // 顶部安全区适配需同时作用于固定导航条与占位元素，保证两者高度一致。避免固定定位的 __content 不继承根元素 padding 而导致占位多预留、露出底部空白
+    const safeAreaTopClass = computed(() => (props.safeAreaInsetTop ? `${classPrefix.value}-safe-area-top` : ''));
 
     const styles = computed<CSSProperties>(() => ({
       zIndex: props.zIndex,
@@ -104,7 +106,7 @@ export default defineComponent({
 
       const renderPlaceholder = () => {
         if (fixed && placeholder) {
-          return <div class={`${navbarClass.value}__placeholder`}></div>;
+          return <div class={[`${navbarClass.value}__placeholder`, safeAreaTopClass.value]}></div>;
         }
         return null;
       };
@@ -112,7 +114,7 @@ export default defineComponent({
       return (
         <div class={navClass.value} style={styles.value}>
           {renderPlaceholder()}
-          <div class={`${navbarClass.value}__content`}>
+          <div class={[`${navbarClass.value}__content`, safeAreaTopClass.value]}>
             {renderLeft()}
             {renderCenter()}
             {renderRight()}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2247 
fix #2106 

### 相关 PRs
https://github.com/Tencent/tdesign-common/pull/2605

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题： 部分机型中，导航栏底部留白
原因：见 #2106。当 safe-area-inset-top=true 时，组件会给根元素 .t-navbar 加上 .t-safe-area-top 类： padding-top 加在根元素上：
- 对普通流里的 placeholder 有效 → 占位高度变成 env(safe-area-inset-top) + 48px
- 对 position: fixed 的 content 无效（fixed 相对视口定位，忽略父级 padding）→ 实际可见栏仍只有 48px

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Navbar): 修复 env(safe-area-inset-top) 非 0 时占位栏高度错误导致底部留白

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
