### PR TITLE
refactor(components): use PascalCase literal style

### DIFF
--- a/src/action-sheet/action-sheet.tsx
+++ b/src/action-sheet/action-sheet.tsx
@@ -3,16 +3,13 @@ import TActionSheetGrid from './action-sheet-grid';
 import TActionSheetList from './action-sheet-list';
 import TButton from '../button';
 import TPopup from '../popup';
-import config from '../config';
 import { useConfig, usePrefixClass } from '../hooks/useClass';
 import useVModel from '../hooks/useVModel';
 import props from './props';
 import { ActionSheetItem, TdActionSheetProps } from './type';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-action-sheet`,
+  name: 'TActionSheet',
   props,
   emits: ['selected', 'update:modelValue', 'cancel', 'close', 'update:visible'],
   setup(props, context) {

--- a/src/avatar/avatar-group.tsx
+++ b/src/avatar/avatar-group.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, Fragment, provide, RendererNode } from 'vue';
 import AvatarGroupProps from './avatar-group-props';
-import config from '../config';
 import TAvatar from './avatar';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { isValidSize } from '../_common/js/avatar/utils';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-avatar-group`,
+  name: 'TAvatarGroup',
   props: AvatarGroupProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/avatar/avatar.tsx
+++ b/src/avatar/avatar.tsx
@@ -1,17 +1,14 @@
 import { computed, defineComponent, inject } from 'vue';
 import TBadge from '../badge';
 import TImage from '../image';
-import config from '../config';
 import AvatarProps from './props';
 import { TdAvatarGroupProps, TdAvatarProps } from './type';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { isValidSize } from '../_common/js/avatar/utils';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-avatar`,
+  name: 'TAvatar',
   props: AvatarProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/back-top/back-top.tsx
+++ b/src/back-top/back-top.tsx
@@ -4,15 +4,12 @@ import { BacktopIcon as TIconBackTop } from 'tdesign-icons-vue-next';
 
 import { isBrowser } from '../shared';
 import props from './props';
-import config from '../config';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import getScrollParent from '../_util/getScrollParent';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-back-top`,
+  name: 'TBackTop',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/badge/badge.tsx
+++ b/src/badge/badge.tsx
@@ -1,14 +1,11 @@
 import { defineComponent, computed, CSSProperties } from 'vue';
 import { isNumber, isString } from 'lodash-es';
-import config from '../config';
 import BadgeProps from './props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-badge`,
+  name: 'TBadge',
   props: BadgeProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -2,16 +2,13 @@ import { computed, defineComponent } from 'vue';
 import TLoading from '../loading';
 import { Hover } from '../shared';
 import ButtonProps from './props';
-import config from '../config';
 import { useFormDisabled } from '../form/hooks';
 import { TdButtonProps } from './type';
 import { usePrefixClass } from '../hooks/useClass';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-button`,
+  name: 'TButton',
   directives: { Hover },
   props: ButtonProps,
   setup(props) {

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -1,15 +1,12 @@
 import { provide, watch, ref, reactive, nextTick, onMounted, defineComponent, toRefs } from 'vue';
 import TPopup from '../popup';
-import config from '../config';
 import props from './props';
 import { useTNodeJSX } from '../hooks/tnode';
 import TCalendarTemplate from './template';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-calendar`,
+  name: 'TCalendar',
   props,
   emits: ['update:visible'],
   setup(props, context) {

--- a/src/calendar/template.tsx
+++ b/src/calendar/template.tsx
@@ -7,17 +7,14 @@ import {
   ChevronRightDoubleIcon,
 } from 'tdesign-icons-vue-next';
 import TButton from '../button';
-import config from '../config';
 import props from './template-props';
 import { useTNodeJSX } from '../hooks/tnode';
 import { TdCalendarProps, TDate, TDateType, CalendarValue, TCalendarValue } from './type';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 import { getPrevMonth, getPrevYear, getNextMonth, getNextYear } from './utils';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-calendar-template`,
+  name: 'TCalendarTemplate',
   props,
   emits: ['visible-change'],
   setup(_props, context) {

--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -4,7 +4,6 @@ import { get as lodashGet } from 'lodash-es';
 import TPopup from '../popup';
 import { Tabs } from '../tabs';
 import { RadioValue, RadioGroup as TRadioGroup } from '../radio';
-import config from '../config';
 import props from './props';
 import { TreeOptionData } from '../common';
 import { useConfig } from '../config-provider/useConfig';
@@ -12,9 +11,6 @@ import useVModel from '../hooks/useVModel';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { CascaderTriggerSource } from './type';
-
-const { prefix } = config;
-const name = `${prefix}-cascader`;
 
 interface ChildrenInfoType {
   value: string | number | boolean;
@@ -34,7 +30,7 @@ interface KeysType {
 }
 
 export default defineComponent({
-  name,
+  name: 'TCascader',
   props,
   emits: ['update:visible', 'update:value', 'update:modelValue'],
   setup(props, { emit, expose }) {

--- a/src/cell/cell-group.tsx
+++ b/src/cell/cell-group.tsx
@@ -1,13 +1,10 @@
 import { computed, defineComponent } from 'vue';
 import props from './cell-group-props';
-import config from '../config';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-cell-group`,
+  name: 'TCellGroup',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/cell/cell.tsx
+++ b/src/cell/cell.tsx
@@ -1,16 +1,13 @@
 import { computed, defineComponent } from 'vue';
 import { ChevronRightIcon } from 'tdesign-icons-vue-next';
 import { Hover } from '../shared';
-import config from '../config';
 import props from './props';
 import { useFormDisabled } from '../form/hooks';
 import { usePrefixClass } from '../hooks/useClass';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-cell`,
+  name: 'TCell',
   directives: { Hover },
   props,
   setup(props) {

--- a/src/checkbox/checkbox-group.tsx
+++ b/src/checkbox/checkbox-group.tsx
@@ -1,6 +1,5 @@
 import { provide, computed, defineComponent, toRefs } from 'vue';
 import { get as lodashGet } from 'lodash-es';
-import config from '../config';
 import props from './checkbox-group-props';
 import { KeysType } from '../common';
 import log from '../_common/js/log';
@@ -11,14 +10,12 @@ import { getOptions, setCheckAllStatus } from './hooks';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export interface Child {
   value: string | number;
 }
 
 export default defineComponent({
-  name: `${prefix}-checkbox-group`,
+  name: 'TCheckboxGroup',
   components: {
     Checkbox,
   },

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -8,7 +8,6 @@ import {
   MinusRectangleFilledIcon,
   CheckRectangleFilledIcon,
 } from 'tdesign-icons-vue-next';
-import config from '../config';
 import CheckboxProps from './props';
 import { TNode } from '../shared';
 import useVModel from '../hooks/useVModel';
@@ -17,10 +16,8 @@ import { useTNodeJSX, useContent } from '../hooks/tnode';
 import { useFormDisabled } from '../form/hooks';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-checkbox`,
+  name: 'TCheckbox',
   components: { TNode },
   props: CheckboxProps,
   emits: ['update:checked', 'update:modelValue', 'change'],

--- a/src/checkbox/hooks/getOptions.ts
+++ b/src/checkbox/hooks/getOptions.ts
@@ -41,7 +41,7 @@ export const getOptions = (props: any, slots: Slots) => {
   const updateOptionListBySlots = () => {
     const nodes = slots.default && slots.default();
     if (nodes !== undefined) {
-      optionList.value = getOptionListBySlots(useChildSlots('t-checkbox'));
+      optionList.value = getOptionListBySlots(useChildSlots('TCheckbox'));
     }
   };
 

--- a/src/collapse/collapse-panel.tsx
+++ b/src/collapse/collapse-panel.tsx
@@ -2,16 +2,13 @@ import { computed, defineComponent, inject, onMounted } from 'vue';
 import { ChevronDownIcon, ChevronUpIcon } from 'tdesign-icons-vue-next';
 import TCell from '../cell';
 import props from './collapse-panel-props';
-import config from '../config';
 import { findIndex } from './util';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { CollapseProvide } from './collapse';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-collapse-panel`,
+  name: 'TCollapsePanel',
   components: { TCell },
   props,
   setup(props, { slots }) {

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -1,6 +1,5 @@
 import { toRefs, provide, defineComponent, computed, Ref, ComputedRef } from 'vue';
 import props from './props';
-import config from '../config';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import useVModel from '../hooks/useVModel';
@@ -14,10 +13,8 @@ export interface CollapseProvide {
   defaultExpandAll: boolean;
 }
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-collapse`,
+  name: 'TCollapse',
   props,
   setup(props, { slots }) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/color-picker/color-picker.tsx
+++ b/src/color-picker/color-picker.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, ref, watch, computed, onMounted, nextTick, toRefs } from 'vue';
 import props from './props';
-import config from '../config';
 import { Popup as TPopup } from '../popup';
 import type { ColorPickerChangeTrigger } from './type';
 import { useTNodeJSX } from '../hooks/tnode';
@@ -11,10 +10,8 @@ import { Color, getColorObject } from '../_common/js/color-picker';
 import { DEFAULT_COLOR } from '../_common/js/color-picker/constants';
 import { ALPHA_MAX, HUE_MAX } from './constants';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-color-picker`,
+  name: 'TColorPicker',
   components: {
     TPopup,
   },

--- a/src/config-provider/config-provider.tsx
+++ b/src/config-provider/config-provider.tsx
@@ -1,14 +1,10 @@
 import { defineComponent } from 'vue';
-import config from '../config';
 import props from './props';
 import { provideConfig } from './useConfig';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-const name = `${prefix}-config-provider`;
-
 export default defineComponent({
-  name,
+  name: 'TConfigProvider',
   props,
   setup(props) {
     provideConfig(props);

--- a/src/count-down/count-down.tsx
+++ b/src/count-down/count-down.tsx
@@ -1,14 +1,11 @@
 import { computed, defineComponent, onBeforeUnmount, onMounted, ref } from 'vue';
-import config from '../config';
 import CountDownProps from './props';
 import { useCountDown } from '../shared/useCountDown';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-count-down`,
+  name: 'TCountDown',
   props: CountDownProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/date-time-picker/date-time-picker.tsx
+++ b/src/date-time-picker/date-time-picker.tsx
@@ -5,7 +5,6 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import objectSupport from 'dayjs/plugin/objectSupport';
 import { isArray } from 'lodash-es';
 
-import config from '../config';
 import DateTimePickerProps from './props';
 import { getMeaningColumn } from './shared';
 import useVModel from '../hooks/useVModel';
@@ -20,10 +19,8 @@ dayjs.extend(weekday);
 dayjs.extend(customParseFormat);
 dayjs.extend(objectSupport);
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-date-time-picker`,
+  name: 'TDateTimePicker',
   components: { TPicker },
   props: DateTimePickerProps,
   emits: ['change', 'cancel', 'confirm', 'pick', 'update:modelValue', 'update:value'],

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -4,16 +4,13 @@ import { get, isString, isObject } from 'lodash-es';
 
 import TButton, { ButtonProps } from '../button';
 import TPopup from '../popup';
-import config from '../config';
 import props from './props';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { TdDialogProps } from './type';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-dialog`,
+  name: 'TDialog',
   props,
   emits: ['update:visible', 'confirm', 'overlay-click', 'cancel', 'close', 'closed'],
   setup(props, context) {

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,13 +1,10 @@
 import { defineComponent, computed } from 'vue';
-import config from '../config';
 import DividerProps from './props';
 import { useContent } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-divider`,
+  name: 'TDivider',
   props: DividerProps,
   setup(props) {
     const renderTNodeContent = useContent();

--- a/src/drawer/__test__/index.test.jsx
+++ b/src/drawer/__test__/index.test.jsx
@@ -48,7 +48,7 @@ describe('drawer', () => {
         },
       });
 
-      const $overlay = wrapper.findComponent({ name: 't-overlay' });
+      const $overlay = wrapper.findComponent({ name: 'TOverlay' });
       expect($overlay.exists()).toBeTruthy();
 
       $overlay.find('.t-overlay').trigger('click');
@@ -90,7 +90,7 @@ describe('drawer', () => {
         },
       });
 
-      const $popup = wrapper.findComponent({ name: 't-popup' });
+      const $popup = wrapper.findComponent({ name: 'TPopup' });
       expect($popup.exists()).toBeTruthy();
       $popup.vm.$emit('visible-change', visible.value);
       expect($popup.emitted()['visible-change'].length).toBe(1);
@@ -117,7 +117,7 @@ describe('drawer', () => {
         },
       });
 
-      const $popup = wrapper.findComponent({ name: 't-popup' });
+      const $popup = wrapper.findComponent({ name: 'TPopup' });
       expect($popup.exists()).toBeTruthy();
       $popup.vm.$emit('close');
       expect($popup.emitted().close).toBeTruthy();

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -1,15 +1,12 @@
 import { ref, watch, toRefs, defineComponent, h } from 'vue';
 import TPopup from '../popup';
-import config from '../config';
 import props from './props';
 import { DrawerItem } from './type';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-drawer`,
+  name: 'TDrawer',
   props,
   emits: ['update:visible', 'itemClick', 'overlayClick'],
   setup(props, context) {

--- a/src/dropdown-menu/dropdown-item.tsx
+++ b/src/dropdown-menu/dropdown-item.tsx
@@ -1,7 +1,6 @@
 import { computed, defineComponent, inject, nextTick, onBeforeMount, reactive, ref, toRefs, watch } from 'vue';
 import { get as lodashGet } from 'lodash-es';
 import TRadio, { RadioGroup as TRadioGroup } from '../radio';
-import config from '../config';
 import TButton from '../button';
 import TPopup from '../popup';
 import TCheckbox, { CheckboxGroup as TCheckboxGroup } from '../checkbox';
@@ -14,12 +13,10 @@ import useVModel from '../hooks/useVModel';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { useConfig, usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 const getUniqueID = uniqueFactory('dropdown-popup');
 
 export default defineComponent({
-  name: `${prefix}-dropdown-item`,
+  name: 'TDropdownItem',
   props,
   emits: ['change', 'open', 'opened', 'close', 'closed', 'update:value', 'update:modelValue'],
   setup(props) {

--- a/src/dropdown-menu/dropdown-menu.tsx
+++ b/src/dropdown-menu/dropdown-menu.tsx
@@ -2,7 +2,6 @@ import { defineComponent, computed, ref, reactive, watch, provide } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { CaretDownSmallIcon, CaretUpSmallIcon } from 'tdesign-icons-vue-next';
 import { camelCase, get as lodashGet, isFunction } from 'lodash-es';
-import config from '../config';
 import {
   context as menuContext,
   DropdownMenuState,
@@ -17,10 +16,8 @@ import DropdownMenuProps from './props';
 import { TdDropdownItemProps } from './type';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-dropdown-menu`,
+  name: 'TDropdownMenu',
   components: { CaretDownSmallIcon, CaretUpSmallIcon },
   props: {
     onMenuOpened: Function,
@@ -45,7 +42,7 @@ export default defineComponent({
     const menuItems = ref<any>([]);
     const updateItems = () => {
       if (slots.default) {
-        const itemName = `${prefix}-dropdown-item`;
+        const itemName = 'TDropdownItem';
         const children = slots.default();
         menuItems.value = children.filter((child: any) => {
           const childTypeName = child?.type?.name;

--- a/src/empty/empty.tsx
+++ b/src/empty/empty.tsx
@@ -1,15 +1,12 @@
 import { defineComponent } from 'vue';
 import TImage from '../image';
 import EmptyProps from './props';
-import config from '../config';
 
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-empty`,
+  name: 'TEmpty',
   props: EmptyProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/fab/fab.tsx
+++ b/src/fab/fab.tsx
@@ -1,5 +1,4 @@
 import { defineComponent, ref, computed, onMounted, watch } from 'vue';
-import config from '../config';
 import FabProps from './props';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
@@ -7,10 +6,8 @@ import TButton from '../button';
 import { TdFabProps } from './type';
 import { reconvertUnit } from '../shared';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-fab`,
+  name: 'TFab',
   props: FabProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -1,13 +1,10 @@
 import { defineComponent } from 'vue';
 import TImage from '../image';
 import FooterProps from './props';
-import config from '../config';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-footer`,
+  name: 'TFooter',
   props: FooterProps,
   setup(props) {
     const footerClass = usePrefixClass('footer');

--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -44,16 +44,13 @@ import {
   SuccessListType,
   ValidateStatus,
 } from './const';
-import config from '../config';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
-
-const { prefix } = config;
 
 export type FormItemValidateResult<T extends Data = Data> = { [key in keyof T]: boolean | AllValidateResult[] };
 
 export default defineComponent({
-  name: `${prefix}-form-item`,
+  name: 'TFormItem',
   props,
   setup(props, { slots }) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -12,14 +12,11 @@ import {
 import props from './props';
 import { FormInjectionKey, FormItemContext } from './const';
 import { FormDisabledProvider } from './hooks';
-import config from '../config';
 import { renderContent } from '../shared';
 import { preventDefault } from '../shared/dom';
 import { FormItemValidateResult } from './form-item';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
-
-const { prefix } = config;
 
 type FormResetEvent = Event;
 // export type FormSubmitEvent = SubmitEvent; (for higher typescript version)
@@ -39,7 +36,7 @@ export const requestSubmit = (target: HTMLFormElement) => {
 };
 
 export default defineComponent({
-  name: `${prefix}-form`,
+  name: 'TForm',
   props,
   setup(props, { expose }) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/grid/grid-item.tsx
+++ b/src/grid/grid-item.tsx
@@ -1,17 +1,14 @@
 import { defineComponent, computed, inject } from 'vue';
 import { isFunction, isString, isObject } from 'lodash-es';
 import { Hover } from '../shared';
-import config from '../config';
 import props from './grid-item-props';
 import { useTNodeJSX } from '../hooks/tnode';
 import TImage from '../image';
 import TBadge from '../badge';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-grid-item`,
+  name: 'TGridItem',
   directives: { Hover },
   components: { TImage, TBadge },
   props,

--- a/src/grid/grid.tsx
+++ b/src/grid/grid.tsx
@@ -1,13 +1,10 @@
 import { defineComponent, provide, toRefs, computed } from 'vue';
 
-import config from '../config';
 import props from './props';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-grid`,
+  name: 'TGrid',
   props,
   setup(props, { slots }) {
     const gridClass = usePrefixClass('grid');

--- a/src/guide/guide.tsx
+++ b/src/guide/guide.tsx
@@ -3,7 +3,6 @@ import { isFunction } from 'lodash-es';
 import TPopover, { PopoverProps } from '../popover';
 import TPopup, { PopupProps } from '../popup';
 import TButton, { ButtonProps } from '../button';
-import config from '../config';
 import useVModel from '../hooks/useVModel';
 import { addClass, getWindowScroll, removeClass } from '../shared/dom';
 import setStyle from '../_common/js/utils/setStyle';
@@ -14,10 +13,8 @@ import { GuideCrossProps } from './interface';
 import { SizeEnum } from '../common';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-guide`,
+  name: 'TGuide',
   components: {
     TPopover,
     TButton,

--- a/src/guide/utils/dom.ts
+++ b/src/guide/utils/dom.ts
@@ -101,7 +101,8 @@ export function getScrollParent(element: HTMLElement) {
 
   if (style.position === 'fixed') return document.body;
 
-  for (let parent = element; parent.parentElement;) {
+  let parent = element;
+  while (parent.parentElement) {
     parent = parent.parentElement;
     style = window.getComputedStyle(parent);
     if (excludeStaticParent && style.position === 'static') {

--- a/src/image-viewer/image-viewer.tsx
+++ b/src/image-viewer/image-viewer.tsx
@@ -1,7 +1,6 @@
 import { computed, defineComponent, reactive, h, Transition, ref, toRefs, watch, nextTick, onUnmounted } from 'vue';
 import { CloseIcon, DeleteIcon } from 'tdesign-icons-vue-next';
 
-import config from '../config';
 import props from './props';
 import useDefaultValue from '../hooks/useDefaultValue';
 import { isBrowser } from '../shared';
@@ -20,12 +19,10 @@ import {
 } from '../swiper';
 import { TdImageViewerProps, ImageInfo, ImageViewerCloseTrigger, ImageSlotParams } from './type';
 
-const { prefix } = config;
-
 const TAP_TIME = 300;
 
 export default defineComponent({
-  name: `${prefix}-image-viewer`,
+  name: 'TImageViewer',
   props,
   emits: ['close', 'index-change', 'update:visible', 'update:modelValue', 'update:index', 'delete'],
   setup(props, { emit, expose }) {

--- a/src/image/image.tsx
+++ b/src/image/image.tsx
@@ -4,16 +4,13 @@ import { useIntersectionObserver } from '@vueuse/core';
 import { CloseIcon } from 'tdesign-icons-vue-next';
 
 import TLoading from '../loading';
-import config from '../config';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
 import props from './props';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-image`,
+  name: 'TImage',
   props,
   setup(props, context) {
     const imageClass = usePrefixClass('image');

--- a/src/indexes/indexes-anchor.tsx
+++ b/src/indexes/indexes-anchor.tsx
@@ -1,13 +1,10 @@
 import { ComponentInternalInstance, defineComponent, getCurrentInstance, inject, onBeforeUnmount } from 'vue';
-import config from '../config';
 import indexesAnchorProps from './indexes-anchor-props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-indexes-anchor`,
+  name: 'TIndexesAnchor',
   props: indexesAnchorProps,
   setup(props) {
     const readerTNodeJSX = useTNodeJSX();

--- a/src/indexes/indexes.tsx
+++ b/src/indexes/indexes.tsx
@@ -14,7 +14,6 @@ import {
 } from 'vue';
 import { throttle } from 'lodash-es';
 import { preventDefault } from '../shared/dom';
-import config from '../config';
 import IndexesProps from './props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
@@ -34,10 +33,8 @@ interface GroupTop {
   totalHeight: number;
 }
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-indexes`,
+  name: 'TIndexes',
   props: IndexesProps,
   emits: ['select', 'change', 'update:current'],
   setup(props) {

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -5,7 +5,6 @@ import {
   CloseCircleFilledIcon as TCloseCircleFilledIcon,
 } from 'tdesign-icons-vue-next';
 import { isFunction } from 'lodash-es';
-import config from '../config';
 import InputProps from './props';
 import { InputValue } from './type';
 import { extendAPI } from '../shared';
@@ -16,10 +15,8 @@ import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 import useLengthLimit from '../hooks/useLengthLimit';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-input`,
+  name: 'TInput',
   props: {
     ...InputProps,
     labelAlign: {

--- a/src/layout/col.tsx
+++ b/src/layout/col.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, CSSProperties, inject } from 'vue';
 import { convertUnit } from '../shared';
 import props from './col-props';
-import config from '../config';
 import { rowInjectionKey } from './constants';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-col`,
+  name: 'TCol',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/layout/row.tsx
+++ b/src/layout/row.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, CSSProperties, provide } from 'vue';
 import { convertUnit } from '../shared';
 import props from './row-props';
-import config from '../config';
 import { rowInjectionKey } from './constants';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-row`,
+  name: 'TRow',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/link/link.tsx
+++ b/src/link/link.tsx
@@ -1,13 +1,11 @@
 import { defineComponent, computed } from 'vue';
-import config from '../config';
 import props from './props';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { useFormDisabled } from '../form/hooks';
 
-const { prefix } = config;
 export default defineComponent({
-  name: `${prefix}-link`,
+  name: 'TLink',
   props,
   setup(props) {
     const linkClass = usePrefixClass('link');

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -2,15 +2,12 @@ import { defineComponent, ref } from 'vue';
 import { useWindowSize, useEventListener } from '@vueuse/core';
 import { useTNodeJSX } from '../hooks/tnode';
 import TLoading from '../loading';
-import config from '../config';
 import props from './props';
 import { useScrollParent } from '../shared';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-list`,
+  name: 'TList',
   components: {
     TLoading,
   },

--- a/src/loading/icon/gradient.tsx
+++ b/src/loading/icon/gradient.tsx
@@ -1,12 +1,9 @@
 import { defineComponent, nextTick, onMounted, onUpdated, ref, CSSProperties, PropType } from 'vue';
 import circleAdapter from '../../_common/js/loading/circle-adapter';
-import config from '../../config';
 import { usePrefixClass } from '../../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-gradient`,
+  name: 'TGradient',
   props: {
     style: Object as PropType<CSSProperties>,
   },

--- a/src/loading/icon/spinner.tsx
+++ b/src/loading/icon/spinner.tsx
@@ -1,12 +1,9 @@
 import { CSSProperties, PropType, defineComponent } from 'vue';
-import config from '../../config';
 
 import { usePrefixClass } from '../../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-spinner`,
+  name: 'TSpinner',
   props: {
     style: Object as PropType<CSSProperties>,
   },

--- a/src/loading/loading.tsx
+++ b/src/loading/loading.tsx
@@ -2,16 +2,13 @@ import { defineComponent, computed, ref, watch, h, setBlockTracking, Teleport, o
 import TGradientIcon from './icon/gradient';
 import SpinnerIcon from './icon/spinner';
 
-import config from '../config';
 import props from './props';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { addClass, getAttach, removeClass } from '../shared/dom';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-loading`,
+  name: 'TLoading',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/message/message.tsx
+++ b/src/message/message.tsx
@@ -5,13 +5,11 @@ import { isString, isObject } from 'lodash-es';
 import Link from '../link';
 import props from './props';
 import { MessageMarquee, TdMessageProps } from './type';
-import config from '../config';
 import { hasStyleUnit } from '../_common/js/utils/helper';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 
-const { prefix } = config;
 const iconDefault = {
   info: h(InfoCircleFilledIcon),
   success: h(CheckCircleFilledIcon),
@@ -30,7 +28,7 @@ export interface MessagePluginOptions extends TdMessageProps {
 }
 
 export default defineComponent({
-  name: `${prefix}-message`,
+  name: 'TMessage',
   props,
   setup(props, context) {
     const messageClass = usePrefixClass('message');

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -1,14 +1,11 @@
 import { defineComponent, computed, CSSProperties } from 'vue';
 import { ChevronLeftIcon } from 'tdesign-icons-vue-next';
-import config from '../config';
 import props from './props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-navbar`,
+  name: 'TNavbar',
   props,
   emits: ['left-click', 'right-click'],
   setup(props, { slots }) {

--- a/src/notice-bar/notice-bar.tsx
+++ b/src/notice-bar/notice-bar.tsx
@@ -4,12 +4,9 @@ import { isArray, isObject } from 'lodash-es';
 import { Swiper as TSwiper, SwiperItem as TSwiperItem } from '../swiper';
 import props from './props';
 import { NoticeBarTrigger, NoticeBarMarquee } from './type';
-import config from '../config';
 import useVModel from '../hooks/useVModel';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
-
-const { prefix } = config;
 
 const iconDefault = {
   info: <InfoCircleFilledIcon />,
@@ -18,7 +15,7 @@ const iconDefault = {
   error: <ErrorCircleFilledIcon />,
 };
 export default defineComponent({
-  name: `${prefix}-notice-bar`,
+  name: 'TNoticeBar',
   props,
   emits: ['change'],
   setup(props) {

--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -1,14 +1,11 @@
 import { Transition, computed, defineComponent } from 'vue';
 import { preventDefault } from '../shared/dom';
-import config from '../config';
 import OverlayProps from './props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-overlay`,
+  name: 'TOverlay',
   props: OverlayProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/picker/picker-item.tsx
+++ b/src/picker/picker-item.tsx
@@ -1,16 +1,13 @@
 import { ref, computed, onMounted, onBeforeUnmount, defineComponent, PropType, watch, inject } from 'vue';
 import { get as lodashGet } from 'lodash-es';
-import config from '../config';
 import Picker from './picker.class';
 import { KeysType } from '../common';
 import { PickerColumnItem, PickerValue, PickerWheelConfig, TdPickerProps } from './type';
 import { usePrefixClass } from '../hooks/useClass';
 import { DEFAULT_WHEEL_CONFIG } from './constants';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-picker-item`,
+  name: 'TPickerItem',
   props: {
     options: {
       type: Array as PropType<PickerColumnItem[]>,

--- a/src/picker/picker.tsx
+++ b/src/picker/picker.tsx
@@ -1,6 +1,5 @@
 import { computed, defineComponent, toRefs, ref, watch, provide } from 'vue';
 import { isBoolean, isFunction, isString, get as lodashGet } from 'lodash-es';
-import config from '../config';
 import PickerProps from './props';
 import { KeysType } from '../common';
 import { PickerValue, PickerColumn, PickerColumnItem, PickerWheelConfig } from './type';
@@ -11,15 +10,13 @@ import { getPickerColumns } from './utils';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 import { DEFAULT_WHEEL_CONFIG } from './constants';
 
-const { prefix } = config;
-
 const getIndexFromColumns = (column: PickerColumn, value: PickerValue, keys?: KeysType) => {
   if (!value) return 0;
   return column?.findIndex((item: PickerColumnItem) => lodashGet(item, keys?.value ?? 'value') === value);
 };
 
 export default defineComponent({
-  name: `${prefix}-picker`,
+  name: 'TPicker',
   components: { PickerItem },
   props: PickerProps,
   emits: ['change', 'cancel', 'pick', 'update:modelValue', 'update:value'],

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -2,16 +2,13 @@ import { defineComponent, computed, ref, toRefs, watch, onUnmounted, Transition 
 import { createPopper, Placement } from '@popperjs/core';
 import PopoverProps from './props';
 import { TdPopoverProps } from './type';
-import config from '../config';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import { useClickAway } from '../shared';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-popover`,
+  name: 'TPopover',
   props: PopoverProps,
   emits: ['visible-change', 'update:visible', 'update:modelValue'],
   setup(props, context) {

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -3,7 +3,6 @@ import { CloseIcon } from 'tdesign-icons-vue-next';
 
 import popupProps from './props';
 import TOverlay from '../overlay';
-import config from '../config';
 import { TdPopupProps } from './type';
 import { TNode, isBrowser } from '../shared';
 import useVModel from '../hooks/useVModel';
@@ -12,10 +11,8 @@ import { useLockScroll } from '../hooks/useLockScroll';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import useTeleport from '../hooks/useTeleport';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-popup`,
+  name: 'TPopup',
   components: { TNode, TOverlay },
   inheritAttrs: false,
   props: popupProps,

--- a/src/progress/progress.tsx
+++ b/src/progress/progress.tsx
@@ -7,12 +7,9 @@ import { getBackgroundColor } from './utils';
 import props from './props';
 import { PRO_THEME, STATUS_ICON, PLUMP_SEPARATE } from '../_common/js/progress/const';
 import { getDiameter, getCircleStokeWidth } from '../_common/js/progress/utils';
-import config from '../config';
-
-const { prefix } = config;
 
 export default defineComponent({
-  name: `${prefix}-progress`,
+  name: 'TProgress',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/pull-down-refresh/pull-down-refresh.tsx
+++ b/src/pull-down-refresh/pull-down-refresh.tsx
@@ -4,14 +4,11 @@ import { throttle } from 'lodash-es';
 import PullDownRefreshProps from './props';
 import { convertUnit, reconvertUnit } from '../shared';
 import { preventDefault } from '../shared/dom';
-import config from '../config';
 import TLoading from '../loading';
 import useVModel from '../hooks/useVModel';
 import { useContent } from '../hooks/tnode';
 import { useTouch, isReachTop, easeDistance, getScrollParent } from './useTouch';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
-
-const { prefix } = config;
 
 const statusName = ['pulling', 'loosing', 'loading', 'success', 'initial'];
 
@@ -19,7 +16,7 @@ const statusName = ['pulling', 'loosing', 'loading', 'success', 'initial'];
 const SCROLL_TO_LOWER_THRESHOLD = 20;
 
 export default defineComponent({
-  name: `${prefix}-pull-down-refresh`,
+  name: 'TPullDownRefresh',
   components: { TLoading },
   props: PullDownRefreshProps,
   emits: ['refresh', 'timeout', 'scrolltolower', 'update:value', 'update:modelValue'],

--- a/src/radio/radio-group.tsx
+++ b/src/radio/radio-group.tsx
@@ -3,16 +3,13 @@ import { get as lodashGet } from 'lodash-es';
 import props from '../radio/radio-group-props';
 import { RadioOption, RadioOptionObj, RadioValue, TdRadioGroupProps } from '../radio/type';
 import TRadio from './radio';
-import config from '../config';
 import { KeysType } from '../common';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-radio-group`,
+  name: 'TRadioGroup',
   props,
   setup(props, context) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -1,6 +1,5 @@
 import { inject, computed, defineComponent, Ref, toRefs } from 'vue';
 import { CheckIcon, CheckCircleFilledIcon } from 'tdesign-icons-vue-next';
-import config from '../config';
 import props from './props';
 import { TdRadioGroupProps, TdRadioProps } from './type';
 import useVModel from '../hooks/useVModel';
@@ -8,10 +7,8 @@ import { useFormDisabled } from '../form/hooks';
 import { usePrefixClass } from '../hooks/useClass';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-radio`,
+  name: 'TRadio',
   props,
   emits: ['update:checked', 'update:modelValue', 'change'],
   setup(props, context) {

--- a/src/rate/rate.tsx
+++ b/src/rate/rate.tsx
@@ -2,16 +2,13 @@ import { computed, defineComponent, ref, toRefs, h } from 'vue';
 import { StarFilledIcon } from 'tdesign-icons-vue-next';
 import { onClickOutside } from '@vueuse/core';
 import props from './props';
-import config from '../config';
 import { TdRateProps } from './type';
 import useVModel from '../hooks/useVModel';
 import { useFormDisabled } from '../form/hooks';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-rate`,
+  name: 'TRate',
   props,
   setup(props, context) {
     const rateClass = usePrefixClass('rate');

--- a/src/result/result.tsx
+++ b/src/result/result.tsx
@@ -1,16 +1,13 @@
 import { computed, defineComponent } from 'vue';
 import { InfoCircleIcon, CheckCircleIcon, CloseCircleIcon } from 'tdesign-icons-vue-next';
-import config from '../config';
 import ResultProps from './props';
 import { useTNodeJSX } from '../hooks/tnode';
 import TImage from '../image';
 import { useIcon } from '../hooks/icon';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-result`,
+  name: 'TResult',
   props: ResultProps,
   setup(props) {
     const resultClass = usePrefixClass('result');

--- a/src/search/search.tsx
+++ b/src/search/search.tsx
@@ -1,7 +1,6 @@
 import { SearchIcon as TSearchIcon, CloseCircleFilledIcon as TIconClear } from 'tdesign-icons-vue-next';
 import { ref, toRefs, computed, defineComponent, nextTick, h } from 'vue';
 import { useFocus } from '@vueuse/core';
-import config from '../config';
 import { preventDefault } from '../shared/dom';
 import searchProps from './props';
 import useVModel from '../hooks/useVModel';
@@ -12,12 +11,10 @@ import { TdSearchProps } from './type';
 import { ENTER_REG } from '../_common/js/common';
 import TCell from '../cell/cell';
 
-const { prefix } = config;
-
 type EnterKeyHint = 'search' | 'done' | 'enter' | 'go' | 'next' | 'previous' | 'send';
 
 export default defineComponent({
-  name: `${prefix}-search`,
+  name: 'TSearch',
   props: searchProps,
   setup(props, context) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/segmented/segmented.tsx
+++ b/src/segmented/segmented.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, h, nextTick, onMounted, ref, toRefs, watch } from 'vue';
 import { isFunction } from 'lodash-es';
-import config from '../config';
 import props from './props';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 import { useResizeObserver } from '../hooks/useResizeObserver';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-segmented`,
+  name: 'TSegmented',
   props,
   emits: ['update:value', 'update:modelValue', 'change'],
   setup(props) {

--- a/src/side-bar/side-bar-item.tsx
+++ b/src/side-bar/side-bar-item.tsx
@@ -4,13 +4,10 @@ import { TdSideBarItemProps } from './type';
 import TBadge from '../badge';
 import { useTNodeJSX } from '../hooks/tnode';
 
-import config from '../config';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-side-bar-item`,
+  name: 'TSideBarItem',
   props,
   setup(props) {
     const sideBarItemClass = usePrefixClass('side-bar-item');

--- a/src/side-bar/side-bar.tsx
+++ b/src/side-bar/side-bar.tsx
@@ -1,15 +1,12 @@
 import { defineComponent, ref, Ref, toRefs, ComponentInternalInstance, provide } from 'vue';
-import config from '../config';
 import props from './props';
 import { TdSideBarProps } from './type';
 import useVModel from '../hooks/useVModel';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-side-bar`,
+  name: 'TSideBar',
   props,
   emits: ['update:value', 'update:modelValue', 'change'],
   setup(props, context) {

--- a/src/skeleton/skeleton.tsx
+++ b/src/skeleton/skeleton.tsx
@@ -2,12 +2,9 @@ import { h, defineComponent, watch, ref } from 'vue';
 import { isArray, isFunction, isNumber } from 'lodash-es';
 import { useContent } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
-import config from '../config';
 import SkeletonProps from './props';
 import { SkeletonRowCol, SkeletonRowColObj, TdSkeletonProps } from './type';
 import { ClassName, Styles } from '../common';
-
-const { prefix } = config;
 
 const ThemeMap: Record<TdSkeletonProps['theme'], SkeletonRowCol> = {
   avatar: [{ type: 'circle', size: '48px' }],
@@ -49,7 +46,7 @@ const getColItemStyle = (obj: SkeletonRowColObj & Record<string, any>): Styles =
 };
 
 export default defineComponent({
-  name: `${prefix}-skeleton`,
+  name: 'TSkeleton',
   props: SkeletonProps,
   setup(props, { slots }) {
     const isShow = ref(false);

--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, onMounted, reactive, ref, toRefs, watch } from 'vue';
 import { isFunction } from 'lodash-es';
 import { useIntersectionObserver } from '@vueuse/core';
-import config from '../config';
 import props from './props';
 import useVModel from '../hooks/useVModel';
 import { trimSingleValue, trimValue } from './tool';
 import type { SliderValue } from './type';
 import { useFormDisabled } from '../form/hooks';
 import { usePrefixClass } from '../hooks/useClass';
-
-const { prefix } = config;
 
 type dataType = {
   initialLeft: number;
@@ -33,7 +30,7 @@ export interface TouchData {
 }
 
 export default defineComponent({
-  name: `${prefix}-slider`,
+  name: 'TSlider',
   props,
   setup(props) {
     const sliderClass = usePrefixClass('slider');

--- a/src/stepper/stepper.tsx
+++ b/src/stepper/stepper.tsx
@@ -1,6 +1,5 @@
 import { toRefs, computed, defineComponent } from 'vue';
 import { AddIcon, RemoveIcon } from 'tdesign-icons-vue-next';
-import config from '../config';
 import props from './props';
 import { formatNumber } from '../shared';
 import { TdStepperProps } from './type';
@@ -8,9 +7,8 @@ import { useFormDisabled } from '../form/hooks';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
 export default defineComponent({
-  name: `${prefix}-stepper`,
+  name: 'TStepper',
   props,
   setup(props, context) {
     const stepperClass = usePrefixClass('stepper');

--- a/src/steps/step-item.tsx
+++ b/src/steps/step-item.tsx
@@ -1,14 +1,11 @@
 import { computed, inject, defineComponent, getCurrentInstance, h, onUnmounted, ComponentInternalInstance } from 'vue';
 import { CloseIcon, CheckIcon } from 'tdesign-icons-vue-next';
 import props from './step-item-props';
-import config from '../config';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-step-item`,
+  name: 'TStepItem',
   props,
   setup(props, context) {
     const stepItemClass = usePrefixClass('step-item');

--- a/src/steps/steps.tsx
+++ b/src/steps/steps.tsx
@@ -1,15 +1,12 @@
 import { provide, defineComponent, reactive, ComponentInternalInstance, computed, toRefs } from 'vue';
 import props from './props';
-import config from '../config';
 import { TdStepsProps } from './type';
 import useVModel from '../hooks/useVModel';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-steps`,
+  name: 'TSteps',
   props,
   emits: ['update:current', 'update:modelValue', 'change'],
   setup(props, context) {

--- a/src/sticky/sticky.tsx
+++ b/src/sticky/sticky.tsx
@@ -1,15 +1,12 @@
 import { computed, defineComponent, ref, watch } from 'vue';
 import { useElementBounding } from '@vueuse/core';
 import StickyProps from './props';
-import config from '../config';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 import useElementRect from '../hooks/useElementRect';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-sticky`,
+  name: 'TSticky',
   props: StickyProps,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/swipe-cell/swipe-cell.tsx
+++ b/src/swipe-cell/swipe-cell.tsx
@@ -12,15 +12,12 @@ import {
 import { isArray, isBoolean } from 'lodash-es';
 import { useSwipe } from './useSwipe';
 import props from './props';
-import config from '../config';
 import { SwipeActionItem, SwipeSource } from './type';
 import { useClickAway } from '../shared';
 import { preventDefault } from '../shared/dom';
 import { useSureConfirm } from './useSureConfirm';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
-
-const { prefix } = config;
 
 export interface SwipeInitData {
   moving: boolean;
@@ -33,7 +30,7 @@ export interface SwipeInitData {
 }
 
 export default defineComponent({
-  name: `${prefix}-swipe-cell`,
+  name: 'TSwipeCell',
   props,
   setup(props, context) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/swiper/swiper-item.tsx
+++ b/src/swiper/swiper-item.tsx
@@ -3,12 +3,8 @@ import { useElementBounding } from '@vueuse/core';
 import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 
-import config from '../config';
-
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-swiper-item`,
+  name: 'TSwiperItem',
   setup() {
     const { addChild, removeChild, isVertical, root, items, setContainerHeight, moveDirection, loop } = inject(
       'parent',

--- a/src/swiper/swiper.tsx
+++ b/src/swiper/swiper.tsx
@@ -1,7 +1,6 @@
 import { onMounted, computed, ref, provide, watch, onUnmounted, toRefs, defineComponent, nextTick } from 'vue';
 import { isNumber } from 'lodash-es';
 import { useSwipe } from '../swipe-cell/useSwipe';
-import config from '../config';
 import props from './props';
 import { SwiperChangeSource, SwiperNavigation } from './type';
 import useVModel from '../hooks/useVModel';
@@ -22,8 +21,6 @@ const DEFAULT_SWIPER_NAVIGATION: SwiperNavigation = {
  */
 const SWIPE_THRESHOLD = 100;
 
-const { prefix } = config;
-
 // 定义 SwiperItem 的接口
 interface SwiperItemInstance {
   uid: number;
@@ -32,7 +29,7 @@ interface SwiperItemInstance {
 }
 
 export default defineComponent({
-  name: `${prefix}-swiper`,
+  name: 'TSwiper',
   props: {
     ...props,
     disabled: {

--- a/src/switch/switch.tsx
+++ b/src/switch/switch.tsx
@@ -2,17 +2,14 @@ import { computed, defineComponent, h, toRefs } from 'vue';
 import { isArray, isFunction, isString } from 'lodash-es';
 import TLoading from '../loading';
 import useToggle from '../hooks/useToggle';
-import config from '../config';
 import props from './props';
 import { SwitchValue, TdSwitchProps } from './type';
 import { useFormDisabled } from '../form/hooks';
 import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-switch`,
+  name: 'TSwitch',
   props,
   setup(props, context) {
     const switchClass = usePrefixClass('switch');

--- a/src/tab-bar/tab-bar-item.tsx
+++ b/src/tab-bar/tab-bar-item.tsx
@@ -2,16 +2,13 @@ import { defineComponent, inject, computed, ref, watch, ComponentInternalInstanc
 import { ViewListIcon as TViewListIcon } from 'tdesign-icons-vue-next';
 import TBadge from '../badge';
 import { TdBadgeProps } from '../badge/type';
-import config from '../config';
 import { initName } from './useTabBar';
 import TabBarItemProps from './tab-bar-item-props';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import { usePrefixClass, useConfig } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-tab-bar-item`,
+  name: 'TTabBarItem',
   components: { TBadge, TViewListIcon },
   props: TabBarItemProps,
   setup(props, context) {

--- a/src/tab-bar/tab-bar.tsx
+++ b/src/tab-bar/tab-bar.tsx
@@ -1,16 +1,13 @@
 import { defineComponent, ref, provide, Ref, computed, toRefs, VNode, CSSProperties } from 'vue';
 import TabBarProps from './props';
-import config from '../config';
 import useChildSlots from '../hooks/useChildSlots';
 import useVModel from '../hooks/useVModel';
 import { useTNodeJSX } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import useElementRect from '../hooks/useElementRect';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-tab-bar`,
+  name: 'TTabBar',
   props: TabBarProps,
   emits: ['update:value', 'update:modelValue', 'change'],
   setup(props, context) {
@@ -64,7 +61,7 @@ export default defineComponent({
         return;
       }
 
-      const childSlots = useChildSlots(`${prefix}-tab-bar-item`, vNodes);
+      const childSlots = useChildSlots('TTabBarItem', vNodes);
       itemCount.value = childSlots.length;
     };
 

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -1,7 +1,6 @@
 import { defineComponent, computed, h, ref, SetupContext, toRefs } from 'vue';
 import { get, isFunction, isString } from 'lodash-es';
 import baseTableProps from './base-table-props';
-import config from '../config';
 import useClassName from './hooks/useClassName';
 import useStyle, { formatCSSUnit } from './hooks/useStyle';
 import useFixed, { getRowFixedStyles, getColumnFixedStyles } from './hooks/useFixed';

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -23,10 +23,8 @@ import { TdLoadingProps } from '../loading/type';
 import { useConfig } from '../config-provider/useConfig';
 import { useTNodeJSX } from '../hooks/tnode';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-base-table`,
+  name: 'TBaseTable',
   props: baseTableProps,
   emits: ['cell-click', 'row-click', 'scroll', 'scroll-to-bottom'],
   setup(props, context) {

--- a/src/tabs/tab-nav-item.tsx
+++ b/src/tabs/tab-nav-item.tsx
@@ -6,7 +6,7 @@ import { useContent, useTNodeJSX } from '../hooks/tnode';
 const { prefix } = config;
 
 export default defineComponent({
-  name: `${prefix}-tab-nav`,
+  name: 'TTabNav',
   props: {
     label: TabPanelProps.label,
     icon: TabPanelProps.icon,

--- a/src/tabs/tab-nav-item.tsx
+++ b/src/tabs/tab-nav-item.tsx
@@ -1,9 +1,7 @@
 import { defineComponent } from 'vue';
-import config from '../config';
 import TabPanelProps from './tab-panel-props';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
-
-const { prefix } = config;
+import { usePrefixClass } from '../hooks/useClass';
 
 export default defineComponent({
   name: 'TTabNav',
@@ -12,6 +10,7 @@ export default defineComponent({
     icon: TabPanelProps.icon,
   },
   setup() {
+    const tabsClass = usePrefixClass('tabs');
     const renderTNodeJSX = useTNodeJSX();
     const renderTNodeContent = useContent();
 
@@ -21,7 +20,7 @@ export default defineComponent({
 
       return (
         <>
-          {iconContent && <div class={`${prefix}-tabs__icon`}>{iconContent}</div>}
+          {iconContent && <div class={`${tabsClass.value}__icon`}>{iconContent}</div>}
           {labelContent}
         </>
       );

--- a/src/tabs/tab-panel.tsx
+++ b/src/tabs/tab-panel.tsx
@@ -1,15 +1,11 @@
 import { defineComponent, inject, Ref, computed, ref, watch } from 'vue';
-import config from '../config';
 import props from './tab-panel-props';
 import { useContent } from '../hooks/tnode';
 import { usePrefixClass } from '../hooks/useClass';
 import { TabValue } from '.';
 
-const { prefix } = config;
-const name = `${prefix}-tab-panel`;
-
 export default defineComponent({
-  name,
+  name: 'TTabPanel',
   props,
   setup(props) {
     const renderTNodeContent = useContent();

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -15,7 +15,6 @@ import {
   RendererNode,
 } from 'vue';
 import { isFunction } from 'lodash-es';
-import config from '../config';
 import props from './props';
 import TTabNavItem from './tab-nav-item';
 import useVModel from '../hooks/useVModel';
@@ -29,14 +28,13 @@ import { usePrefixClass } from '../hooks/useClass';
 import { useCommonClassName } from '../hooks/useCommonClassName';
 import { Styles } from '../common';
 
-const { prefix } = config;
-
 export default defineComponent({
   name: 'TTabs',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();
     const tabsClass = usePrefixClass('tabs');
+    const badgeClass = usePrefixClass('badge');
     const { SIZE } = useCommonClassName();
 
     const stickyProps = computed(() => ({ ...(props.stickyProps as TdStickyProps), disabled: !props.sticky }));
@@ -110,7 +108,7 @@ export default defineComponent({
         const tab = navWrap.value.querySelector<HTMLElement>(`.${activeClass}`);
         if (!tab) return;
         const line = navLine.value;
-        const tabInner = tab.querySelector<HTMLElement>(`.${prefix}-badge`);
+        const tabInner = tab.querySelector<HTMLElement>(`.${badgeClass.value}`);
         const style: Styles = { opacity: 1 };
         if (props.bottomLineMode === 'auto') {
           style.width = `${Number(tabInner?.offsetWidth)}px`;

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -32,7 +32,7 @@ import { Styles } from '../common';
 const { prefix } = config;
 
 export default defineComponent({
-  name: `${prefix}-tabs`,
+  name: 'TTabs',
   props,
   setup(props) {
     const renderTNodeJSX = useTNodeJSX();
@@ -89,7 +89,7 @@ export default defineComponent({
         });
       };
       handler(children);
-      children = res.filter((child: RendererNode) => child.type.name === `${prefix}-tab-panel`);
+      children = res.filter((child: RendererNode) => child.type.name === 'TTabPanel');
       return children.map((item: RendererNode, index: number) => ({
         ...item.props,
         label: () => label[index] || item.props.label,

--- a/src/tag/check-tag.tsx
+++ b/src/tag/check-tag.tsx
@@ -1,15 +1,12 @@
 import { defineComponent, computed, toRefs } from 'vue';
 import { CloseIcon } from 'tdesign-icons-vue-next';
-import config from '../config';
 import CheckTagProps from './check-tag-props';
 import { usePrefixClass } from '../hooks/useClass';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import useVModel from '../hooks/useVModel';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-check-tag`,
+  name: 'TCheckTag',
   props: CheckTagProps,
   setup(props) {
     const tagClass = usePrefixClass('tag');

--- a/src/tag/tag.tsx
+++ b/src/tag/tag.tsx
@@ -1,14 +1,11 @@
 import { computed, defineComponent } from 'vue';
 import { CloseIcon } from 'tdesign-icons-vue-next';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
-import config from '../config';
 import TagProps from './props';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-tag`,
+  name: 'TTag',
   components: {
     CloseIcon,
   },

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -1,6 +1,5 @@
 import { computed, ref, onMounted, defineComponent, toRefs, nextTick, watch, inject } from 'vue';
 import useLengthLimit from '../hooks/useLengthLimit';
-import config from '../config';
 import props from './props';
 import { TextareaValue } from './type';
 import calcTextareaHeight from '../_common/js/utils/calcTextareaHeight';
@@ -10,10 +9,8 @@ import { usePrefixClass } from '../hooks/useClass';
 import { useTNodeJSX } from '../hooks/tnode';
 import useVModel from '../hooks/useVModel';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-textarea`,
+  name: 'TTextarea',
   props,
   setup(props, context) {
     const renderTNodeJSX = useTNodeJSX();

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -3,14 +3,11 @@ import { computed, defineComponent, h, ref } from 'vue';
 import { useContent, useTNodeJSX } from '../hooks/tnode';
 import TOverlay from '../overlay';
 import ToastProps from './props';
-import config from '../config';
 import { useLockScroll } from '../hooks/useLockScroll';
 import { usePrefixClass } from '../hooks/useClass';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-toast`,
+  name: 'TToast',
   props: ToastProps,
   setup(props) {
     const toastTypeIcon = {

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -2,7 +2,6 @@ import { computed, defineComponent, ref, toRefs, watch } from 'vue';
 import { SideBar as TSideBar, SideBarItem as TSideBarItem } from '../side-bar';
 import TRadio, { RadioGroup as TRadioGroup } from '../radio';
 import TCheckbox, { CheckboxGroup as TCheckboxGroup } from '../checkbox';
-import config from '../config';
 import { convertUnit } from '../shared';
 import log from '../_common/js/log';
 import props from './props';
@@ -10,12 +9,10 @@ import { TdTreeSelectProps, TreeSelectValue, _TreeOptionData } from './type';
 import { usePrefixClass } from '../hooks/useClass';
 import useVModel from '../hooks/useVModel';
 
-const { prefix } = config;
-
 type TreeSelectValueGroup = TreeSelectValue[];
 
 export default defineComponent({
-  name: `${prefix}-tree-select`,
+  name: 'TTreeSelect',
   components: {
     TSideBar,
     TSideBarItem,

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -22,7 +22,6 @@ import TImageViewer from '../image-viewer';
 import TButton from '../button';
 import { TdUploadProps, UploadFile } from './type';
 import UploadProps from './props';
-import config from '../config';
 import useUpload from './hooks/useUpload';
 import useDrag from './hooks/useDrag';
 import { useTNodeJSX } from '../hooks/tnode';
@@ -37,12 +36,10 @@ import {
   returnFileSize,
 } from '../_common/js/upload/utils';
 
-const { prefix } = config;
-
 const FILE_ZIP_REGEXP = /(\.zip|\.rar|\.7z|\.tar|\.gz|\.bz2|\.xz)/i;
 
 export default defineComponent({
-  name: `${prefix}-upload`,
+  name: 'TUpload',
   components: {
     TImage,
   },

--- a/src/watermark/watermark.tsx
+++ b/src/watermark/watermark.tsx
@@ -5,14 +5,11 @@ import injectStyle from '../_common/js/utils/injectStyle';
 import { useContent, usePrefixClass, useVariables } from '../hooks';
 import setStyle from '../_common/js/utils/setStyle';
 import { useMutationObserver } from './hooks';
-import config from '../config';
 
 import props from './props';
 
-const { prefix } = config;
-
 export default defineComponent({
-  name: `${prefix}-watermark`,
+  name: 'TWatermark',
   props,
   setup(props) {
     const backgroundImage = ref('');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue
fix #2258 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
目标：组件标签名支持使用 PascalCase
方案：采用 #2258 中的方案2。
为什么没有使用方案1？希望就本次改动，直接对齐桌面端
- 注册键变为 PascalCase → `<TButton>` 与 `<t-button>` 均可用，且与 globals.d.ts 已有类型对齐


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(component): 组件全局注册名及 `$options.name` 由 `kebab-case` (t-button) 变为 `PascalCase` (TButton)，对齐 PC 端。模板中 `<t-button> / <TButton>` 两种写法仍可用，但依赖组件 name 字符串的场景（如 keep-alive 的 include/exclude、按 name key 直接访问组件）需相应更新


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
