### PR TITLE
fix(Typography): remove duplicate Text/Title/Paragraph exports

### DIFF
--- a/src/typography/__test__/typography.test.jsx
+++ b/src/typography/__test__/typography.test.jsx
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
-import { Typography, TypographyText, TypographyTitle, TypographyParagraph } from '../index';
+import { Typography, Text, Title, Paragraph } from '../index';
 
 const prefix = 't';
 const COMPONENT_NAME = `${prefix}-typography`;
@@ -40,8 +40,8 @@ describe('Typography', () => {
 describe('Typography exports', () => {
   it('exports all sub-components', () => {
     expect(Typography).toBeDefined();
-    expect(TypographyText).toBeDefined();
-    expect(TypographyTitle).toBeDefined();
-    expect(TypographyParagraph).toBeDefined();
+    expect(Text).toBeDefined();
+    expect(Title).toBeDefined();
+    expect(Paragraph).toBeDefined();
   });
 });

--- a/src/typography/index.ts
+++ b/src/typography/index.ts
@@ -13,10 +13,8 @@ export type TitleProps = TdTitleProps;
 export type ParagraphProps = TdParagraphProps;
 
 export const Typography = withInstall(_Typography);
-export const TypographyText = withInstall(_Text);
-export const TypographyTitle = withInstall(_Title);
-export const TypographyParagraph = withInstall(_Paragraph);
-
-export { _Text as Text, _Title as Title, _Paragraph as Paragraph };
+export const Text = withInstall(_Text);
+export const Title = withInstall(_Title);
+export const Paragraph = withInstall(_Paragraph);
 
 export default Typography;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2275 
fix #2278 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(Typography): 移除重复导出的组件 `Text/Title/Paragraph`，修复 "Plugin has already been applied" 告警

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
