### PR TITLE
fix(Swiper): provide correct navigation type

### DIFF
--- a/src/swiper/props.ts
+++ b/src/swiper/props.ts
@@ -66,7 +66,7 @@ export default {
   },
   /** 导航器全部配置 */
   navigation: {
-    type: [Object, Function] as PropType<TdSwiperProps['navigation']>,
+    type: [Object, Function, Boolean] as PropType<TdSwiperProps['navigation']>,
   },
   /** 【开发中】后边距，可用于露出后一项的一小部分。默认单位 `px` */
   nextMargin: {

--- a/src/swiper/type.ts
+++ b/src/swiper/type.ts
@@ -59,7 +59,7 @@ export interface TdSwiperProps {
   /**
    * 导航器全部配置
    */
-  navigation?: SwiperNavigation | TNode;
+  navigation?: SwiperNavigation | TNode | boolean;
   /**
    * 【开发中】后边距，可用于露出后一项的一小部分。默认单位 `px`
    * @default 0


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fixes #2304

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

打开 ImageViewer 时 vue 报错类型不匹配。

将布尔值添加到 Swiper 类型校验中即可解决（实际代码有针对 true 的处理，false 则默认走 `return {} as SwiperNavigation;`

```ts
# src\swiper\swiper.tsx 67-79 行
const navigationConfig = computed<SwiperNavigation>(() => {
  if (props.navigation === true || props.navigation === undefined) {
    return DEFAULT_SWIPER_NAVIGATION;
  }
  if (typeof props.navigation === 'object' && props.navigation !== null) {
    return {
      ...DEFAULT_SWIPER_NAVIGATION,
      ...props.navigation,
    } as SwiperNavigation;
  }

  return {} as SwiperNavigation;
});
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Swiper): provide correct navigation type

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
